### PR TITLE
Optimise replacing peer config

### DIFF
--- a/wireguard.go
+++ b/wireguard.go
@@ -61,7 +61,23 @@ func setPeers(deviceName string, peers []wgtypes.PeerConfig) error {
 	if deviceName == "" {
 		deviceName = defaultWireguardDeviceName
 	}
-	return wg.ConfigureDevice(deviceName, wgtypes.Config{ReplacePeers: true, Peers: peers})
+	device, err := wg.Device(deviceName)
+	if err != nil {
+		return err
+	}
+	for _, ep := range device.Peers {
+		found := false
+		for _, np := range peers {
+			if ep.PublicKey.String() == np.PublicKey.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			peers = append(peers, wgtypes.PeerConfig{PublicKey: ep.PublicKey, Remove: true})
+		}
+	}
+	return wg.ConfigureDevice(deviceName, wgtypes.Config{Peers: peers})
 }
 
 func addNetlinkRoute() error {

--- a/wireguard.go
+++ b/wireguard.go
@@ -67,7 +67,8 @@ func setPeers(deviceName string, peers []wgtypes.PeerConfig) error {
 	}
 	for _, ep := range device.Peers {
 		found := false
-		for _, np := range peers {
+		for i, np := range peers {
+			peers[i].ReplaceAllowedIPs = true
 			if ep.PublicKey.String() == np.PublicKey.String() {
 				found = true
 				break


### PR DESCRIPTION
Using `ReplacePeers` causes a small hiccup while wireguard re-configures. Instead, we could just patch the config by identifying peers to be removed and upserting the rest.

Additionally, we use `ReplaceAllowedIPs` for peers, which doesn't seem to affect connectivity.