### PR TITLE
Rename devices to interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 **This is an experimental project and still at the very early stages.**
 
+Table of Contents
+=================
+
+   * [wiresteward](#wiresteward)
+      * [Usage](#usage)
+      * [Agent](#agent)
+         * [Getting and running the agent](#getting-and-running-the-agent)
+         * [Agent config](#agent-config)
+         * [Dev aws config - Example](#dev-aws-config---example)
+
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
+
 # wiresteward
 
 [![Docker Repository on Quay](https://quay.io/repository/utilitywarehouse/wiresteward/status "Docker Repository on Quay")](https://quay.io/repository/utilitywarehouse/wiresteward)
@@ -24,3 +36,66 @@ public
 | `WGS_SERVER_PEER_CONFIG_PATH` | path to the JSON file containing server configuration | `server.json`
 
 `wiresteward agent --config=path-to-config.json`
+
+## Agent
+
+### Getting and running the agent
+
+Agent binaries can be found under wiresteward releases:
+https://github.com/utilitywarehouse/wiresteward/releases
+
+to install on linux simply:
+
+```
+wget -O /usr/bin/wiresteward https://github.com/utilitywarehouse/wiresteward/releases/download/v0.1.0-rc0/wiresteward_0.1.0-rc0_linux_amd64
+chmod +x /usr/bin/wiresteward
+```
+
+A successful wiresteward agent run will:
+
+- create new network devices
+- Generate and post wireguard keys
+- Configure wireguard peers
+- Configure routes for the subnets advertised by the server
+
+thus it needs NET_ADMIN capabilities.
+
+To run simply:
+```
+wiresteward agent --config=path-to-config.json
+```
+
+### Agent config
+
+Agent takes a config file as an argument (or `~/wiresteward.json` if not
+specified), from where it gets all the details needed to get a token from okta
+and create/update the wg interfaces and routes after talking to the remote
+wiresteward peers.
+
+An example, where the config format can be found is here:
+https://github.com/utilitywarehouse/wiresteward/blob/master/agent.json.example
+
+
+### Dev aws config - Example
+
+A config file to talk to the dev-aws wiresteward servers:
+
+```
+{
+  "oidc": {
+    "clientID": "0oa5lj5deYlDCe8Es416",
+    "authUrl": "https://login.uw.systems/oauth2/v1/authorize",
+    "tokenUrl": "https://login.uw.systems/oauth2/v1/token"
+  },
+  "devs": [
+    {
+      "name": "wg-dev-aws",
+      "peers": [
+        {
+          "url": "https://wireguard.dev.aws.uw.systems"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A config file to talk to the dev-aws wiresteward servers:
     "authUrl": "https://login.uw.systems/oauth2/v1/authorize",
     "tokenUrl": "https://login.uw.systems/oauth2/v1/token"
   },
-  "devs": [
+  "interfaces": [
     {
       "name": "wg-dev-aws",
       "peers": [

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A config file to talk to the dev-aws wiresteward servers:
   },
   "interfaces": [
     {
-      "name": "wg-dev-aws",
+      "name": "wg-uw-dev-aws",
       "peers": [
         {
           "url": "https://wireguard.dev.aws.uw.systems"

--- a/agent.json.example
+++ b/agent.json.example
@@ -4,7 +4,7 @@
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
   },
-  "devs": [
+  "interfaces": [
     {
       "name": "wg_test",
       "peers": [

--- a/config.go
+++ b/config.go
@@ -17,14 +17,14 @@ type AgentPeerConfig struct {
 	Url string `json:"url"`
 }
 
-type AgentDevConfig struct {
+type AgentInterfaceConfig struct {
 	Name  string            `json:"name"`
 	Peers []AgentPeerConfig `json:"peers"`
 }
 
 type AgentConfig struct {
-	Oidc AgentOidcConfig  `json:"oidc"`
-	Devs []AgentDevConfig `json:"devs"`
+	Oidc       AgentOidcConfig        `json:"oidc"`
+	Interfaces []AgentInterfaceConfig `json:"interfaces"`
 }
 
 func unmarshalAgentConfig(data []byte, v interface{}) error {
@@ -45,12 +45,12 @@ func verifyAgentOidcConfig(conf *AgentConfig) error {
 	return nil
 }
 
-func verifyAgentDevsConfig(conf *AgentConfig) error {
-	for _, dev := range conf.Devs {
-		if dev.Name == "" {
-			return fmt.Errorf("Device name not specified in config")
+func verifyAgentInterfacesConfig(conf *AgentConfig) error {
+	for _, iface := range conf.Interfaces {
+		if iface.Name == "" {
+			return fmt.Errorf("Interface name not specified in config")
 		}
-		for _, peer := range dev.Peers {
+		for _, peer := range iface.Peers {
 			if peer.Url == "" {
 				return fmt.Errorf("Missing peer url from config")
 			}
@@ -78,7 +78,7 @@ func readAgentConfig(path string) (*AgentConfig, error) {
 	if err = verifyAgentOidcConfig(conf); err != nil {
 		return nil, err
 	}
-	if err = verifyAgentDevsConfig(conf); err != nil {
+	if err = verifyAgentInterfacesConfig(conf); err != nil {
 		return nil, err
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -31,9 +31,9 @@ func TestAgentConfigFmt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	devsOnly := []byte(`
+	interfacesOnly := []byte(`
 {
-  "devs": [
+  "interfaces": [
     {
       "name": "wg_test",
       "peers": [
@@ -50,18 +50,18 @@ func TestAgentConfigFmt(t *testing.T) {
 `)
 
 	conf = &AgentConfig{}
-	err = unmarshalAgentConfig(devsOnly, conf)
+	err = unmarshalAgentConfig(interfacesOnly, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(conf.Devs), 1)
-	assert.Equal(t, conf.Devs[0].Name, "wg_test")
-	peers := (conf.Devs)[0].Peers
+	assert.Equal(t, len(conf.Interfaces), 1)
+	assert.Equal(t, conf.Interfaces[0].Name, "wg_test")
+	peers := (conf.Interfaces)[0].Peers
 	assert.Equal(t, len(peers), 2)
 	assert.Equal(t, peers[0].Url, "example1.com")
 	assert.Equal(t, peers[1].Url, "example2.com")
-	err = verifyAgentDevsConfig(conf)
+	err = verifyAgentInterfacesConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestAgentConfigFmt(t *testing.T) {
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
   },
-  "devs": [
+  "interfaces": [
     {
       "name": "wg_test",
       "peers": [
@@ -94,16 +94,16 @@ func TestAgentConfigFmt(t *testing.T) {
 	assert.Equal(t, conf.Oidc.ClientID, "xxxxx")
 	assert.Equal(t, conf.Oidc.AuthUrl, "example.com/auth")
 	assert.Equal(t, conf.Oidc.TokenUrl, "example.com/token")
-	assert.Equal(t, len(conf.Devs), 1)
-	assert.Equal(t, conf.Devs[0].Name, "wg_test")
-	peers = conf.Devs[0].Peers
+	assert.Equal(t, len(conf.Interfaces), 1)
+	assert.Equal(t, conf.Interfaces[0].Name, "wg_test")
+	peers = conf.Interfaces[0].Peers
 	assert.Equal(t, len(peers), 1)
 	assert.Equal(t, peers[0].Url, "example1.com")
 	err = verifyAgentOidcConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = verifyAgentDevsConfig(conf)
+	err = verifyAgentInterfacesConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -147,31 +147,31 @@ func agent() {
 		agentConf.Oidc.ClientID,
 	)
 
-	for _, dev := range agentConf.Devs {
-		// Create an agent for each dev specified in the config
+	for _, iface := range agentConf.Interfaces {
+		// Create an agent for each interface specified in the config
 		agent, err := NewAgent(
-			dev.Name,
+			iface.Name,
 			tokenHandler,
 		)
 		if err != nil {
 			log.Fatalf(
-				"Cannot create agent fot dev: %s : %v",
-				dev.Name,
+				"Cannot create agent fot interface: %s : %v",
+				iface.Name,
 				err,
 			)
 		}
 
-		// Clear all the device ips, new ones will be added according
+		// Clear all the interface ips, new ones will be added according
 		// to peers responses
 		if err := agent.FlushDeviceIPs(); err != nil {
 			log.Fatalf(
-				"Cannot clear ips fot dev: %s : %v",
-				dev.Name,
+				"Cannot clear ips for interface: %s : %v",
+				iface.Name,
 				err,
 			)
 		}
 
-		for _, peer := range dev.Peers {
+		for _, peer := range iface.Peers {
 			if err := agent.GetNewWgLease(peer.Url); err != nil {
 				log.Printf(
 					"cannot get lease from peer: %s :%v",


### PR DESCRIPTION
Left whatever is tied to netlink as device, since that is closer to the names
used in the package.