### PR TITLE
Avoid printing flag defaults when closing agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,10 @@ func main() {
 	if *flagServer {
 		server()
 	}
-	flag.PrintDefaults()
+
+	if !*flagAgent && !*flagServer {
+		flag.PrintDefaults()
+	}
 }
 
 // reads config into serverConfig map[string]string

--- a/main.go
+++ b/main.go
@@ -57,15 +57,15 @@ func main() {
 
 	if *flagAgent {
 		agent()
+		return
 	}
 
 	if *flagServer {
 		server()
+		return
 	}
 
-	if !*flagAgent && !*flagServer {
-		flag.PrintDefaults()
-	}
+	flag.PrintDefaults()
 }
 
 // reads config into serverConfig map[string]string


### PR DESCRIPTION
```
^CINFO: (wg-uw-dev-aws) 2020/07/30 08:15:26 Device closing
  -agent
        Run application in "agent" mode
  -config string
        Config file (only used in agent mode)
  -server
        Run application in "server" mode
  -version
        Prints out application version
```