### PR TITLE
Rename interface to device

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ wiresteward is a peer manager for wireguard instances. It is comprised by a
 server and an agent functionality.
 
 The agents post their public keys to the server and receive back configuration
-to configure the wireguard interfaces on their host machine. The server updates
-its peers list per agent request to add the advertised public key.
+to configure the wireguard devices on their host machine. The server updates its
+peers list per agent request to add the advertised public key.
 
 The server needs to run behind an oauth2 proxy, so that it is not "open" to the
 public
@@ -106,14 +106,14 @@ The agent runs a local server on port 7773 and expects the user to visit
 
 Opening `localhost:7773/` on a browser will trigger the oauth process, if
 necessary, and ask the configured remote server peers for details to configure
-them as wg peers under the respective interface (defined in configuration file,
+them as wg peers under the respective device (defined in configuration file,
 see below)
 
 ### Config
 
 Agent can takes a config file as an argument or look for it under the default
 location `/etc/wiresteward/config.json`, chosen to suit the systemd service.
-The config contains details about the oidc server and the local interfaces that
+The config contains details about the oidc server and the local devices that
 we need the agent to manage.
 
 An example, where the config format can be found is here:
@@ -130,7 +130,7 @@ A config file to talk to the dev-aws wiresteward servers:
     "authUrl": "https://login.uw.systems/oauth2/v1/authorize",
     "tokenUrl": "https://login.uw.systems/oauth2/v1/token"
   },
-  "interfaces": [
+  "devices": [
     {
       "name": "wg-uw-dev-aws",
       "peers": [

--- a/agent.go
+++ b/agent.go
@@ -18,18 +18,18 @@ type Agent struct {
 }
 
 // NewAgent creates an Agent from an AgentConfig. It generates a DeviceManager
-// per interface specified in the configuration, sets up and starts the
-// assocated resources.
+// per device specified in the configuration, sets up and starts the associated
+// resources.
 func NewAgent(cfg *agentConfig) *Agent {
 	agent := &Agent{}
-	for _, iface := range cfg.Interfaces {
+	for _, dev := range cfg.Devices {
 		urls := []string{}
-		for _, peer := range iface.Peers {
+		for _, peer := range dev.Peers {
 			urls = append(urls, peer.URL)
 		}
 		dm := newDeviceManager(urls)
-		if err := dm.Run(iface.Name); err != nil {
-			log.Printf("Error setting up device `%s`: %v", iface.Name, err)
+		if err := dm.Run(dev.Name); err != nil {
+			log.Printf("Error setting up device `%s`: %v", dev.Name, err)
 			dm.Stop()
 			continue
 		}

--- a/agent.json.example
+++ b/agent.json.example
@@ -4,13 +4,13 @@
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
   },
-  "interfaces": [
+  "devices": [
     {
       "name": "wg_test",
       "peers": [
         {
-	  "url": "example1.com"
-	}
+            "url": "example1.com"
+        }
       ]
     }
   ]

--- a/config.go
+++ b/config.go
@@ -28,16 +28,17 @@ type agentPeerConfig struct {
 	URL string `json:"url"`
 }
 
-// agentInterfaceConfig defines an interface and associated wiresteward servers.
-type agentInterfaceConfig struct {
+// agentDeviceConfig defines a network device and associated wiresteward
+// servers.
+type agentDeviceConfig struct {
 	Name  string            `json:"name"`
 	Peers []agentPeerConfig `json:"peers"`
 }
 
 // AgentConfig describes the agent-side configuration of wiresteward.
 type agentConfig struct {
-	Oidc       agentOidcConfig        `json:"oidc"`
-	Interfaces []agentInterfaceConfig `json:"interfaces"`
+	Oidc    agentOidcConfig     `json:"oidc"`
+	Devices []agentDeviceConfig `json:"devices"`
 }
 
 func verifyAgentOidcConfig(conf *agentConfig) error {
@@ -53,12 +54,12 @@ func verifyAgentOidcConfig(conf *agentConfig) error {
 	return nil
 }
 
-func verifyAgentInterfacesConfig(conf *agentConfig) error {
-	for _, iface := range conf.Interfaces {
-		if iface.Name == "" {
-			return fmt.Errorf("Interface name not specified in config")
+func verifyAgentDevicesConfig(conf *agentConfig) error {
+	for _, dev := range conf.Devices {
+		if dev.Name == "" {
+			return fmt.Errorf("Device name not specified in config")
 		}
-		for _, peer := range iface.Peers {
+		for _, peer := range dev.Peers {
 			if peer.URL == "" {
 				return fmt.Errorf("Missing peer url from config")
 			}
@@ -79,7 +80,7 @@ func readAgentConfig(path string) (*agentConfig, error) {
 	if err = verifyAgentOidcConfig(conf); err != nil {
 		return nil, err
 	}
-	if err = verifyAgentInterfacesConfig(conf); err != nil {
+	if err = verifyAgentDevicesConfig(conf); err != nil {
 		return nil, err
 	}
 	return conf, nil

--- a/config_test.go
+++ b/config_test.go
@@ -35,18 +35,18 @@ func TestAgentConfigFmt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	interfacesOnly := []byte(`
+	devicesOnly := []byte(`
 {
-  "interfaces": [
+  "devices": [
     {
       "name": "wg_test",
       "peers": [
         {
-	  "url": "example1.com"
-	},
+            "url": "example1.com"
+        },
         {
-	  "url": "example2.com"
-	}
+            "url": "example2.com"
+        }
       ]
     }
   ]
@@ -54,18 +54,18 @@ func TestAgentConfigFmt(t *testing.T) {
 `)
 
 	conf = &agentConfig{}
-	err = json.Unmarshal(interfacesOnly, conf)
+	err = json.Unmarshal(devicesOnly, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(conf.Interfaces), 1)
-	assert.Equal(t, conf.Interfaces[0].Name, "wg_test")
-	peers := (conf.Interfaces)[0].Peers
+	assert.Equal(t, len(conf.Devices), 1)
+	assert.Equal(t, conf.Devices[0].Name, "wg_test")
+	peers := (conf.Devices)[0].Peers
 	assert.Equal(t, len(peers), 2)
 	assert.Equal(t, peers[0].URL, "example1.com")
 	assert.Equal(t, peers[1].URL, "example2.com")
-	err = verifyAgentInterfacesConfig(conf)
+	err = verifyAgentDevicesConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,13 +77,13 @@ func TestAgentConfigFmt(t *testing.T) {
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
   },
-  "interfaces": [
+  "devices": [
     {
       "name": "wg_test",
       "peers": [
         {
-	  "url": "example1.com"
-	}
+            "url": "example1.com"
+        }
       ]
     }
   ]
@@ -98,16 +98,16 @@ func TestAgentConfigFmt(t *testing.T) {
 	assert.Equal(t, conf.Oidc.ClientID, "xxxxx")
 	assert.Equal(t, conf.Oidc.AuthURL, "example.com/auth")
 	assert.Equal(t, conf.Oidc.TokenURL, "example.com/token")
-	assert.Equal(t, len(conf.Interfaces), 1)
-	assert.Equal(t, conf.Interfaces[0].Name, "wg_test")
-	peers = conf.Interfaces[0].Peers
+	assert.Equal(t, len(conf.Devices), 1)
+	assert.Equal(t, conf.Devices[0].Name, "wg_test")
+	peers = conf.Devices[0].Peers
 	assert.Equal(t, len(peers), 1)
 	assert.Equal(t, peers[0].URL, "example1.com")
 	err = verifyAgentOidcConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = verifyAgentInterfacesConfig(conf)
+	err = verifyAgentDevicesConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/devicemanager_darwin.go
+++ b/devicemanager_darwin.go
@@ -165,7 +165,7 @@ func flushAddresses(fd int, name string) error {
 		ip, err := getAddress(fd, name)
 		if err != nil {
 			if errors.Is(err, unix.EADDRNOTAVAIL) {
-				// there are no more addresses on the interface, we're done here
+				// there are no more addresses on the device, we're done here
 				return nil
 			}
 			return err


### PR DESCRIPTION
This is to stay consistent with upstream naming (such as in the wireguard
packages).