### PR TITLE
Set default tx qlen for server device

### DIFF
--- a/device.go
+++ b/device.go
@@ -162,7 +162,8 @@ type WireguardDevice struct {
 func newWireguardDevice(cfg *serverConfig) *WireguardDevice {
 	link := &netlink.Wireguard{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: cfg.DeviceName,
+			Name:   cfg.DeviceName,
+			TxQLen: 1000,
 		},
 	}
 	return &WireguardDevice{


### PR DESCRIPTION
`wg0` created by wiresteward
`wg1` created by wg-quick

```
2020/08/20 13:54:38 diff:   &netlink.GenericLink{
  	LinkAttrs: netlink.LinkAttrs{
- 		Index:        30,
+ 		Index:        29,
  		MTU:          8921,
- 		TxQLen:       0,
+ 		TxQLen:       1000,
- 		Name:         "wg0",
+ 		Name:         "wg1",
  		HardwareAddr: s"",
  		Flags:        s"up|pointtopoint",
  		... // 19 identical fields
  	},
  	LinkType: "wireguard",
  }
```