### PR TITLE
Use access token expiry time for leases

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@ const (
 	defaultKeyFilename         = "/etc/wiresteward/key"
 	defaultLeaserSyncInterval  = 1 * time.Minute
 	defaultLeasesFilename      = "/etc/wiresteward/leases"
-	defaultLeaseTime           = 12 * time.Hour
 	defaultServerListenAddress = "0.0.0.0:8080"
 )
 
@@ -104,7 +103,6 @@ type serverConfig struct {
 	KeyFilename         string
 	LeaserSyncInterval  time.Duration
 	LeasesFilename      string
-	LeaseTime           time.Duration
 	WireguardIPAddress  net.IP
 	WireguardIPNetwork  *net.IPNet
 	WireguardListenPort int
@@ -123,7 +121,6 @@ func (c *serverConfig) UnmarshalJSON(data []byte) error {
 		KeyFilename         string   `json:"keyFilename"`
 		LeaserSyncInterval  string   `json:"leaserSyncInterval"`
 		LeasesFilename      string   `json:"leasesFilename"`
-		LeaseTime           string   `json:"leaseTime"`
 		OauthIntrospectUrl  string   `json:"oauthIntrospectUrl"`
 		OauthClientId       string   `json:"oauthClientId"`
 		ServerListenAddress string   `json:"serverListenAddress"`
@@ -137,13 +134,6 @@ func (c *serverConfig) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		c.LeaserSyncInterval = lsi
-	}
-	if cfg.LeaseTime != "" {
-		lt, err := time.ParseDuration(cfg.LeaseTime)
-		if err != nil {
-			return err
-		}
-		c.LeaseTime = lt
 	}
 	c.Address = cfg.Address
 	c.AllowedIPs = cfg.AllowedIPs
@@ -198,10 +188,6 @@ func verifyServerConfig(conf *serverConfig) error {
 	if conf.LeasesFilename == "" {
 		conf.LeasesFilename = defaultLeasesFilename
 		log.Printf("config missing `leasesFilename`, using default: %s", defaultLeasesFilename)
-	}
-	if conf.LeaseTime == 0 {
-		conf.LeaseTime = defaultLeaseTime
-		log.Printf("config missing `leaseTime`, using default: %s", defaultLeaseTime)
 	}
 	if conf.OauthIntrospectUrl == "" {
 		return fmt.Errorf("config missing `oauthIntrospectUrl`")

--- a/config_test.go
+++ b/config_test.go
@@ -139,7 +139,6 @@ func TestServerConfig(t *testing.T) {
 				KeyFilename:         defaultKeyFilename,
 				LeaserSyncInterval:  defaultLeaserSyncInterval,
 				LeasesFilename:      defaultLeasesFilename,
-				LeaseTime:           defaultLeaseTime,
 				WireguardIPAddress:  ip,
 				WireguardIPNetwork:  net,
 				WireguardListenPort: 1234,
@@ -158,7 +157,6 @@ func TestServerConfig(t *testing.T) {
 				"keyFilename": "bar",
 				"leaserSyncInterval": "3h",
 				"leasesFilename": "foo",
-				"leaseTime": "2h",
 				"oauthIntrospectUrl": "example.com",
 				"oauthClientId": "client_id"
 			}`),
@@ -170,7 +168,6 @@ func TestServerConfig(t *testing.T) {
 				KeyFilename:         "bar",
 				LeasesFilename:      "foo",
 				LeaserSyncInterval:  time.Duration(time.Hour * 3),
-				LeaseTime:           time.Duration(time.Hour * 2),
 				WireguardIPAddress:  ip,
 				WireguardIPNetwork:  net,
 				WireguardListenPort: 12345,

--- a/lease_test.go
+++ b/lease_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -36,8 +37,9 @@ func TestFileLeaseManager_createOrUpdatePeer(t *testing.T) {
 	testPubKey1 := "k1a1fEw+lqB/JR1pKjI597R54xzfP9Kxv4M7hufyNAY="
 	testPubKey2 := "E1gSkv2jS/P+p8YYmvm7ByEvwpLPqQBdx70SPtNSwCo="
 	testUsername := "test@example.com"
+	expiry := time.Unix(0, 0)
 
-	_, err := lm.createOrUpdatePeer(testUsername, testPubKey1)
+	_, err := lm.createOrUpdatePeer(testUsername, testPubKey1, expiry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,14 +47,14 @@ func TestFileLeaseManager_createOrUpdatePeer(t *testing.T) {
 	assert.Equal(t, testPubKey1, lm.wgRecords[testUsername].PubKey)
 	// Test that same username with different public key will replace the
 	// existing record, instead of adding a new one
-	_, err = lm.createOrUpdatePeer(testUsername, testPubKey2)
+	_, err = lm.createOrUpdatePeer(testUsername, testPubKey2, expiry)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, 1, len(lm.wgRecords))
 	assert.Equal(t, testPubKey2, lm.wgRecords[testUsername].PubKey)
 	// Test that empty username will error
-	_, err = lm.createOrUpdatePeer("", testPubKey2)
+	_, err = lm.createOrUpdatePeer("", testPubKey2, expiry)
 	assert.Equal(t, err, fmt.Errorf("Cannot add peer for empty username"))
 }
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func server() {
 		}
 	}()
 
-	lm, err := newFileLeaseManager(cfg.LeasesFilename, cfg.WireguardIPNetwork, cfg.LeaseTime, cfg.WireguardIPAddress)
+	lm, err := newFileLeaseManager(cfg.LeasesFilename, cfg.WireguardIPNetwork, cfg.WireguardIPAddress)
 	if err != nil {
 		log.Fatalf("Cannot start lease server: %v", err)
 	}

--- a/oauth2.go
+++ b/oauth2.go
@@ -158,10 +158,8 @@ func (tv *tokenValidator) requestIntospection(token, tokenTypeHint string) ([]by
 	return body, nil
 }
 
-// validate: validates the token via quering the introspection endpoint. Looks
-// for `active` (required) and `username` (optional) field as per:
+// validate takes a token and queries the introspection endpoint with it.
 // https://tools.ietf.org/html/rfc7662#section-2.2
-// returns: username(string), valid(bool), error
 func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionResponse, error) {
 	body, err := tv.requestIntospection(token, tokenTypeHint)
 	if err != nil {

--- a/oauth2.go
+++ b/oauth2.go
@@ -115,6 +115,7 @@ type tokenValidator struct {
 
 type introspectionResponse struct {
 	Active   bool   `json:"active"`
+	Exp      int64  `json:"exp"`
 	UserName string `json:"username"`
 }
 
@@ -161,15 +162,15 @@ func (tv *tokenValidator) requestIntospection(token, tokenTypeHint string) ([]by
 // for `active` (required) and `username` (optional) field as per:
 // https://tools.ietf.org/html/rfc7662#section-2.2
 // returns: username(string), valid(bool), error
-func (tv *tokenValidator) validate(token, tokenTypeHint string) (string, bool, error) {
+func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionResponse, error) {
 	body, err := tv.requestIntospection(token, tokenTypeHint)
 	if err != nil {
-		return "", false, err
+		return nil, err
 	}
 
 	response := &introspectionResponse{}
 	if err := json.Unmarshal(body, response); err != nil {
-		return "", false, err
+		return nil, err
 	}
-	return response.UserName, response.Active, nil
+	return response, nil
 }

--- a/serve.go
+++ b/serve.go
@@ -71,11 +71,11 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		if !tokenInfo.Active {
-			http.Error(
-				w,
-				"invalid token",
-				http.StatusForbidden,
-			)
+			http.Error(w, "invalid token", http.StatusForbidden)
+			return
+		}
+		if tokenInfo.Exp <= 0 {
+			http.Error(w, "token does not expire, cannot accept this", http.StatusBadRequest)
 			return
 		}
 		decoder := json.NewDecoder(r.Body)

--- a/server.json.example
+++ b/server.json.example
@@ -1,7 +1,7 @@
-[
-  {
-    "Address": "10.0.0.1/24",
-    "Endpoint": "1.2.3.4:51820",
-    "AllowedIPs": ["10.11.12.0/24"]
-  }
-]
+{
+  "address": "10.0.0.1/24",
+  "allowedIPs": ["10.11.12.0/24"],
+  "endpoint": "1.2.3.4:51820",
+  "oauthIntrospectUrl": "https://login.example.com/oauth2/v1/introspect",
+  "oauthClientId": "xxxxxxxxxxxxxxxxx"
+}

--- a/terraform/ignition/ignition.tf
+++ b/terraform/ignition/ignition.tf
@@ -7,12 +7,11 @@ data "ignition_file" "wiresteward_config" {
 
   content {
     content = templatefile("${path.module}/resources/wiresteward-config.json.tmpl", {
-      wireguard_cidr                 = var.wireguard_cidrs[count.index]
-      wireguard_endpoint             = local.wireguard_endpoints[count.index]
-      wireguard_exposed_subnets      = var.wireguard_exposed_subnets
-      wiresteward_address_lease_time = var.wiresteward_address_lease_time
-      oauth2_introspect_url          = var.oauth2_introspect_url
-      oauth2_client_id               = var.oauth2_client_id
+      wireguard_cidr            = var.wireguard_cidrs[count.index]
+      wireguard_endpoint        = local.wireguard_endpoints[count.index]
+      wireguard_exposed_subnets = var.wireguard_exposed_subnets
+      oauth2_introspect_url     = var.oauth2_introspect_url
+      oauth2_client_id          = var.oauth2_client_id
     })
   }
 }

--- a/terraform/ignition/io.tf
+++ b/terraform/ignition/io.tf
@@ -29,12 +29,6 @@ variable "wireguard_exposed_subnets" {
   description = "The subnets that are exposed to wireguard peers in CIDR notation"
 }
 
-variable "wiresteward_address_lease_time" {
-  type        = string
-  description = "Lifetime of wiresteward address leases"
-  default     = "12h"
-}
-
 variable "wiresteward_version" {
   type        = string
   description = "The version of wiresteward to deploy (see https://github.com/utilitywarehouse/wiresteward/)"

--- a/terraform/ignition/resources/wiresteward-config.json.tmpl
+++ b/terraform/ignition/resources/wiresteward-config.json.tmpl
@@ -2,7 +2,6 @@
   "address": "${wireguard_cidr}",
   "allowedIPs": ${jsonencode(wireguard_exposed_subnets)},
   "endpoint": "${wireguard_endpoint}:51820",
-  "leaseTime": "${wiresteward_address_lease_time}",
   "oauthIntrospectUrl": "${oauth2_introspect_url}",
   "oauthClientId": "${oauth2_client_id}"
 }


### PR DESCRIPTION
Remove the leaseTime configuration option for server. The expiry time
of a lease is now the same as the expiry time of the provided access
token.