### PR TITLE
Use global logger for all application logs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -43,8 +43,7 @@ func NewAgent(cfg *agentConfig) *Agent {
 	tokenDir := filepath.Dir(defaultTokenFileLoc)
 	err := os.MkdirAll(tokenDir, 0755)
 	if err != nil {
-		logger.Error.Printf(
-			"Error: unable to create directory=%s", tokenDir)
+		logger.Error.Printf("Unable to create directory=%s", tokenDir)
 	}
 	agent.oa = newOAuthTokenHandler(
 		cfg.Oidc.AuthURL,

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -159,11 +158,14 @@ func verifyServerConfig(conf *serverConfig) error {
 	conf.WireguardIPAddress = ip
 	conf.WireguardIPNetwork = network
 	if len(conf.AllowedIPs) == 0 {
-		log.Printf("config missing `allowedIPs`, this server is not exposing any networks")
+		logger.Info.Printf("config missing `allowedIPs`, this server is not exposing any networks")
 	}
 	if conf.DeviceName == "" {
 		conf.DeviceName = defaultWireguardDeviceName
-		log.Printf("config missing `deviceName`, using default: %s", defaultWireguardDeviceName)
+		logger.Info.Printf(
+			"config missing `deviceName`, using default: %s",
+			defaultWireguardDeviceName,
+		)
 	}
 	if conf.Endpoint == "" {
 		return fmt.Errorf("config missing `endpoint`")
@@ -179,15 +181,24 @@ func verifyServerConfig(conf *serverConfig) error {
 	conf.WireguardListenPort = port
 	if conf.KeyFilename == "" {
 		conf.KeyFilename = defaultKeyFilename
-		log.Printf("config missing `keyFilename`, using default: %s", defaultKeyFilename)
+		logger.Info.Printf(
+			"config missing `keyFilename`, using default: %s",
+			defaultKeyFilename,
+		)
 	}
 	if conf.LeaserSyncInterval == 0 {
 		conf.LeaserSyncInterval = defaultLeaserSyncInterval
-		log.Printf("config missing `leaserSyncInterval`, using default: %s", defaultLeaserSyncInterval)
+		logger.Info.Printf(
+			"config missing `leaserSyncInterval`, using default: %s",
+			defaultLeaserSyncInterval,
+		)
 	}
 	if conf.LeasesFilename == "" {
 		conf.LeasesFilename = defaultLeasesFilename
-		log.Printf("config missing `leasesFilename`, using default: %s", defaultLeasesFilename)
+		logger.Info.Printf(
+			"config missing `leasesFilename`, using default: %s",
+			defaultLeasesFilename,
+		)
 	}
 	if conf.OauthIntrospectURL == "" {
 		return fmt.Errorf("config missing `oauthIntrospectURL`")
@@ -197,7 +208,10 @@ func verifyServerConfig(conf *serverConfig) error {
 	}
 	if conf.ServerListenAddress == "" {
 		conf.ServerListenAddress = defaultServerListenAddress
-		log.Printf("config missing `serverListenAddress`, using default: %s", defaultServerListenAddress)
+		logger.Info.Printf(
+			"config missing `serverListenAddress`, using default: %s",
+			defaultServerListenAddress,
+		)
 	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAgentConfigFmt(t *testing.T) {
 	setLogLevel("error")
-	logger = initLogger("wiresteward-test")
+	logger = newLogger("wiresteward-test")
 	oidcOnly := []byte(`
 {
   "oidc": {
@@ -119,7 +119,7 @@ func TestAgentConfigFmt(t *testing.T) {
 
 func TestServerConfig(t *testing.T) {
 	setLogLevel("error")
-	logger = initLogger("wiresteward-test")
+	logger = newLogger("wiresteward-test")
 	ip, net, _ := net.ParseCIDR("10.0.0.1/24")
 	testCases := []struct {
 		input []byte

--- a/config_test.go
+++ b/config_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestAgentConfigFmt(t *testing.T) {
-
+	setLogLevel("error")
+	logger = initLogger("wiresteward-test")
 	oidcOnly := []byte(`
 {
   "oidc": {
@@ -117,6 +118,8 @@ func TestAgentConfigFmt(t *testing.T) {
 }
 
 func TestServerConfig(t *testing.T) {
+	setLogLevel("error")
+	logger = initLogger("wiresteward-test")
 	ip, net, _ := net.ParseCIDR("10.0.0.1/24")
 	testCases := []struct {
 		input []byte

--- a/device.go
+++ b/device.go
@@ -43,7 +43,7 @@ func newTunDevice(name string, mtu int) *TunDevice {
 		deviceMTU:  mtu,
 		deviceName: name,
 		errs:       make(chan error),
-		logger:     initLogger(fmt.Sprintf("wireguard-go/%s", name)),
+		logger:     newLogger(fmt.Sprintf("wireguard-go/%s", name)),
 	}
 }
 

--- a/devicemanager_darwin.go
+++ b/devicemanager_darwin.go
@@ -46,7 +46,7 @@ func (dm *DeviceManager) updateDeviceConfig(oldConfig, config *WirestewardPeerCo
 		// routes via interfaces.
 		for _, r := range oldConfig.AllowedIPs {
 			if err := delRoute(fdRoute, oldConfig.LocalAddress.IP, r.IP, r.Mask); err != nil {
-				logger.ErrorPrintf(
+				logger.Error.Printf(
 					"Could not remove old route (%s): %s",
 					r,
 					err,

--- a/devicemanager_linux.go
+++ b/devicemanager_linux.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"log"
-
 	"github.com/vishvananda/netlink"
 )
 
@@ -22,11 +20,19 @@ func (dm *DeviceManager) updateDeviceConfig(oldConfig, config *WirestewardPeerCo
 	if oldConfig != nil {
 		for _, r := range oldConfig.AllowedIPs {
 			if h.RouteDel(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: &r}); err != nil {
-				log.Printf("Could not remove old route (%s): %s", r, err)
+				logger.Error.Printf(
+					"Could not remove old route (%s): %s",
+					r,
+					err,
+				)
 			}
 		}
 		if err := h.AddrDel(link, &netlink.Addr{IPNet: oldConfig.LocalAddress}); err != nil {
-			log.Printf("Could not remove old address (%s): %s", oldConfig.LocalAddress, err)
+			logger.Error.Printf(
+				"Could not remove old address (%s): %s",
+				oldConfig.LocalAddress,
+				err,
+			)
 		}
 	}
 	if err := h.AddrAdd(link, &netlink.Addr{IPNet: config.LocalAddress}); err != nil {
@@ -34,7 +40,8 @@ func (dm *DeviceManager) updateDeviceConfig(oldConfig, config *WirestewardPeerCo
 	}
 	for _, r := range config.AllowedIPs {
 		if err := h.RouteAdd(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: &r}); err != nil {
-			log.Printf("Could not add new route (%s): %s", r, err)
+			logger.Error.Printf(
+				"Could not add new route (%s): %s", r, err)
 		}
 	}
 	return nil

--- a/lease.go
+++ b/lease.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -36,11 +35,11 @@ func newFileLeaseManager(filename string, cidr *net.IPNet, ip net.IP) (*FileLeas
 	if filename == "" {
 		return nil, fmt.Errorf("file name cannot be empty")
 	}
-	log.Printf("leases filename: %s\n", filename)
+	logger.Info.Printf("leases filename: %s\n", filename)
 	leaseDir := filepath.Dir(filename)
 	err := os.MkdirAll(leaseDir, 0755)
 	if err != nil {
-		log.Printf("Error: unable to create directory=%s", leaseDir)
+		logger.Error.Printf("Unable to create directory=%s", leaseDir)
 		return nil, err
 	}
 
@@ -52,9 +51,9 @@ func newFileLeaseManager(filename string, cidr *net.IPNet, ip net.IP) (*FileLeas
 		if err != nil {
 			return nil, err
 		}
-		log.Println("records loaded")
+		logger.Info.Println("records loaded")
 	} else {
-		log.Printf("unable to open leases file: %v", err)
+		logger.Error.Printf("unable to open leases file: %v", err)
 	}
 
 	lm := &FileLeaseManager{
@@ -68,7 +67,7 @@ func newFileLeaseManager(filename string, cidr *net.IPNet, ip net.IP) (*FileLeas
 		return nil, err
 	}
 
-	log.Println("Init complete")
+	logger.Info.Println("Init complete")
 	return lm, nil
 }
 
@@ -177,7 +176,7 @@ func updateWgPeers(lm *FileLeaseManager) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("peers: %v\n", peers)
+	logger.Debug.Printf("peers: %v\n", peers)
 	if err := setPeers("", peers); err != nil {
 		return err
 	}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"golang.zx2c4.com/wireguard/device"
+)
+
+// Use device package logger as the global logger for the application.
+// device.Logger is effectively a collection of standard logging library loggers
+var logger *device.Logger
+
+// logLevel global var, defaults to info
+var logLevel = device.LogLevelInfo
+
+// Sets the logLevel global variable. Needs to be called before the
+// initialisation of loggers
+func setLogLevel(level string) {
+	switch level {
+	case "debug":
+		logLevel = device.LogLevelDebug
+	case "info":
+		logLevel = device.LogLevelInfo
+	case "error":
+		logLevel = device.LogLevelError
+	}
+}
+
+// Returns a new logger using the global level variable
+func initLogger(name string) *device.Logger {
+	return device.NewLogger(
+		logLevel,
+		fmt.Sprintf("%s: ", name),
+	)
+}

--- a/logger.go
+++ b/logger.go
@@ -22,6 +22,11 @@ func setLogLevel(level string) {
 		logLevel = device.LogLevelInfo
 	case "error":
 		logLevel = device.LogLevelError
+	default:
+		fmt.Printf(
+			"Invalid log level: %s, can be debug|info|error. Defaulting to info",
+			level,
+		)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -26,7 +26,7 @@ func setLogLevel(level string) {
 }
 
 // Returns a new logger using the global level variable
-func initLogger(name string) *device.Logger {
+func newLogger(name string) *device.Logger {
 	return device.NewLogger(
 		logLevel,
 		fmt.Sprintf("%s: ", name),

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 		return
 	}
 	setLogLevel(*flagLogLevel)
-	logger = initLogger("wiresteward")
+	logger = newLogger("wiresteward")
 
 	if *flagVersion {
 		logger.Info.Println(version)

--- a/oauth2.go
+++ b/oauth2.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -78,7 +77,7 @@ func (oa *oauthTokenHandler) getTokenFromFile() (*oauth2.Token, error) {
 }
 
 func (oa *oauthTokenHandler) saveToken(token *oauth2.Token) error {
-	log.Printf("Saving credential file to: %s", oa.tokFile)
+	logger.Info.Printf("Saving credential file to: %s", oa.tokFile)
 	f, err := os.OpenFile(oa.tokFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("unable to cache oauth token: %w", err)
@@ -101,7 +100,7 @@ func (oa *oauthTokenHandler) ExchangeToken(code string) (*oauth2.Token, error) {
 	}
 
 	if err := oa.saveToken(tok); err != nil {
-		log.Printf("failed to save token to file: %v", err)
+		logger.Error.Printf("failed to save token to file: %v", err)
 	}
 
 	return tok, nil

--- a/serve.go
+++ b/serve.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -52,7 +51,8 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 	case "POST":
 		token, err := extractBearerTokenFromHeader(r, "Authorization")
 		if err != nil {
-			log.Println("Cannot parse authorization token", err)
+			logger.Error.Println(
+				"Cannot parse authorization token", err)
 			http.Error(
 				w,
 				fmt.Sprintf("error parsing auth token: %v", err),
@@ -62,7 +62,7 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 		}
 		tokenInfo, err := lh.tokenValidator.validate(token, "access_token")
 		if err != nil {
-			log.Println("Cannot check token validity", err)
+			logger.Error.Println("Cannot check token validity", err)
 			http.Error(
 				w,
 				fmt.Sprintf("error checking token validity: %v", err),
@@ -81,7 +81,7 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 		decoder := json.NewDecoder(r.Body)
 		var p leaseRequest
 		if err := decoder.Decode(&p); err != nil {
-			log.Println("Cannot decode request body", err)
+			logger.Error.Println("Cannot decode request body", err)
 			http.Error(w, "Cannot decode request body", http.StatusInternalServerError)
 			return
 		}
@@ -113,8 +113,8 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 func (lh *HTTPLeaseHandler) start() {
 	http.HandleFunc("/newPeerLease", lh.newPeerLease)
 
-	log.Printf("Starting server for lease requests\n")
+	logger.Info.Printf("Starting server for lease requests\n")
 	if err := http.ListenAndServe(lh.serverConfig.ServerListenAddress, nil); err != nil {
-		log.Fatal(err)
+		logger.Error.Fatal(err)
 	}
 }

--- a/wireguard.go
+++ b/wireguard.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"net"
 	"time"
 
@@ -52,7 +51,8 @@ func setPeers(deviceName string, peers []wgtypes.PeerConfig) error {
 	}
 	defer func() {
 		if err := wg.Close(); err != nil {
-			log.Printf("Failed to close wireguard client: %v", err)
+			logger.Error.Printf(
+				"Failed to close wireguard client: %v", err)
 		}
 	}()
 	if deviceName == "" {
@@ -85,7 +85,8 @@ func setPrivateKey(deviceName string, privKey string) error {
 	}
 	defer func() {
 		if err := wg.Close(); err != nil {
-			log.Printf("Failed to close wireguard client: %v", err)
+			logger.Error.Printf(
+				"Failed to close wireguard client: %v", err)
 		}
 	}()
 	if deviceName == "" {
@@ -106,7 +107,8 @@ func getKeys(deviceName string) (string, string, error) {
 	}
 	defer func() {
 		if err := wg.Close(); err != nil {
-			log.Printf("Failed to close wireguard client: %v", err)
+			logger.Error.Printf(
+				"Failed to close wireguard client: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Borrow the logger from wireguard device package to bring consistency across
application and tun devices logs