### PR TITLE
Use oauth instead of oidc

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ see below)
 
 Agent can takes a config file as an argument or look for it under the default
 location `/etc/wiresteward/config.json`, chosen to suit the systemd service.
-The config contains details about the oidc server and the local devices that
+The config contains details about the oauth server and the local devices that
 we need the agent to manage.
 
 An example, where the config format can be found is here:
@@ -133,7 +133,7 @@ A config file to talk to the dev-aws wiresteward servers:
 
 ```
 {
-  "oidc": {
+  "oauth": {
     "clientID": "0oa5lj5deYlDCe8Es416",
     "authUrl": "https://login.uw.systems/oauth2/v1/authorize",
     "tokenUrl": "https://login.uw.systems/oauth2/v1/token"

--- a/agent.go
+++ b/agent.go
@@ -46,9 +46,9 @@ func NewAgent(cfg *agentConfig) *Agent {
 		logger.Error.Printf("Unable to create directory=%s", tokenDir)
 	}
 	agent.oa = newOAuthTokenHandler(
-		cfg.Oidc.AuthURL,
-		cfg.Oidc.TokenURL,
-		cfg.Oidc.ClientID,
+		cfg.OAuth.AuthURL,
+		cfg.OAuth.TokenURL,
+		cfg.OAuth.ClientID,
 		defaultTokenFileLoc,
 	)
 	return agent

--- a/agent.json.example
+++ b/agent.json.example
@@ -1,5 +1,5 @@
 {
-  "oidc": {
+  "oauth": {
     "clientID": "xxxxx",
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"

--- a/config.go
+++ b/config.go
@@ -17,8 +17,8 @@ const (
 	defaultServerListenAddress = "0.0.0.0:8080"
 )
 
-// agentOidcConfig encapsulates agent-side OIDC configuration for wiresteward.
-type agentOidcConfig struct {
+// agentOAuthConfig encapsulates agent-side OAuth configuration for wiresteward
+type agentOAuthConfig struct {
 	ClientID string `json:"clientID"`
 	AuthURL  string `json:"authUrl"`
 	TokenURL string `json:"tokenUrl"`
@@ -40,19 +40,19 @@ type agentDeviceConfig struct {
 
 // AgentConfig describes the agent-side configuration of wiresteward.
 type agentConfig struct {
-	Oidc    agentOidcConfig     `json:"oidc"`
+	OAuth   agentOAuthConfig    `json:"oauth"`
 	Devices []agentDeviceConfig `json:"devices"`
 }
 
-func verifyAgentOidcConfig(conf *agentConfig) error {
-	if conf.Oidc.ClientID == "" {
-		return fmt.Errorf("oidc config missing `clientID`")
+func verifyAgentOAuthConfig(conf *agentConfig) error {
+	if conf.OAuth.ClientID == "" {
+		return fmt.Errorf("oauth config missing `clientID`")
 	}
-	if conf.Oidc.AuthURL == "" {
-		return fmt.Errorf("oidc config missing `authUrl`")
+	if conf.OAuth.AuthURL == "" {
+		return fmt.Errorf("oauth config missing `authUrl`")
 	}
-	if conf.Oidc.TokenURL == "" {
-		return fmt.Errorf("oidc config missing `tokenUrl`")
+	if conf.OAuth.TokenURL == "" {
+		return fmt.Errorf("oauth config missing `tokenUrl`")
 	}
 	return nil
 }
@@ -83,7 +83,7 @@ func readAgentConfig(path string) (*agentConfig, error) {
 	if err = json.Unmarshal(fileContent, conf); err != nil {
 		return nil, fmt.Errorf("error unmarshalling config: %v", err)
 	}
-	if err = verifyAgentOidcConfig(conf); err != nil {
+	if err = verifyAgentOAuthConfig(conf); err != nil {
 		return nil, err
 	}
 	if err = verifyAgentDevicesConfig(conf); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -13,9 +13,9 @@ import (
 func TestAgentConfigFmt(t *testing.T) {
 	setLogLevel("error")
 	logger = newLogger("wiresteward-test")
-	oidcOnly := []byte(`
+	oauthOnly := []byte(`
 {
-  "oidc": {
+  "oauth": {
     "clientID": "xxxxx",
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
@@ -23,15 +23,15 @@ func TestAgentConfigFmt(t *testing.T) {
 }
 `)
 	conf := &agentConfig{}
-	err := json.Unmarshal(oidcOnly, conf)
+	err := json.Unmarshal(oauthOnly, conf)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, conf.Oidc.ClientID, "xxxxx")
-	assert.Equal(t, conf.Oidc.AuthURL, "example.com/auth")
-	assert.Equal(t, conf.Oidc.TokenURL, "example.com/token")
-	err = verifyAgentOidcConfig(conf)
+	assert.Equal(t, conf.OAuth.ClientID, "xxxxx")
+	assert.Equal(t, conf.OAuth.AuthURL, "example.com/auth")
+	assert.Equal(t, conf.OAuth.TokenURL, "example.com/token")
+	err = verifyAgentOAuthConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestAgentConfigFmt(t *testing.T) {
 
 	full := []byte(`
 {
-  "oidc": {
+  "oauth": {
     "clientID": "xxxxx",
     "authUrl": "example.com/auth",
     "tokenUrl": "example.com/token"
@@ -98,16 +98,16 @@ func TestAgentConfigFmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, conf.Oidc.ClientID, "xxxxx")
-	assert.Equal(t, conf.Oidc.AuthURL, "example.com/auth")
-	assert.Equal(t, conf.Oidc.TokenURL, "example.com/token")
+	assert.Equal(t, conf.OAuth.ClientID, "xxxxx")
+	assert.Equal(t, conf.OAuth.AuthURL, "example.com/auth")
+	assert.Equal(t, conf.OAuth.TokenURL, "example.com/token")
 	assert.Equal(t, len(conf.Devices), 1)
 	assert.Equal(t, conf.Devices[0].Name, "wg_test")
 	assert.Equal(t, conf.Devices[0].MTU, 1380)
 	peers = conf.Devices[0].Peers
 	assert.Equal(t, len(peers), 1)
 	assert.Equal(t, peers[0].URL, "example1.com")
-	err = verifyAgentOidcConfig(conf)
+	err = verifyAgentOAuthConfig(conf)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Wiresteward is now designed to work with oauth2 access tokens, so we
should rename occurences of 'oidc' to reflect design.