### PR TITLE
Use goreleaser ldflags for version

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,11 @@ import (
 	"time"
 )
 
-const (
-	version = "v0.1.0-dev"
-)
-
 var (
+	version      = "dev"
+	commit       = "none"
+	date         = "unknown"
+	builtBy      = "unknown"
 	flagAgent    = flag.Bool("agent", false, "Run application in \"agent\" mode")
 	flagConfig   = flag.String("config", "/etc/wiresteward/config.json", "Config file")
 	flagLogLevel = flag.String("log-level", "info", "Log Level (debug|info|error)")
@@ -31,7 +31,7 @@ func main() {
 	logger = newLogger("wiresteward")
 
 	if *flagVersion {
-		logger.Info.Println(version)
+		logger.Info.Printf("version=%s commit=%s date=%s builtBy=%s", version, commit, date, builtBy)
 		return
 	}
 


### PR DESCRIPTION
I noticed that the v0.1.0-rc2 release was reporting a different version that is staticly set as a const in main.go. As we're generating binaries with goreleaser, we can take advantage of the ldflags that it sets when it builds:
- https://goreleaser.com/environment/#using-the-mainversion

```
$ ./dist/main_darwin_amd64/wiresteward -version
INFO: wiresteward: 2020/09/02 10:27:45 version=0.1.0-rc300 commit=d21c79225e8e172c321e801646817c507926be4f date=2020-09-02T09:27:21Z builtBy=goreleaser
```