### PR TITLE
terraform/aws: get private addresses from instances

### DIFF
--- a/terraform/aws/io.tf
+++ b/terraform/aws/io.tf
@@ -50,7 +50,7 @@ output "public_ipv4_addresses" {
 }
 
 output "private_ipv4_addresses" {
-  value = aws_eip.peer.*.private_ip
+  value = aws_instance.peer.*.private_ip
 }
 
 output "security_group_id" {


### PR DESCRIPTION
When the instance is re-created the eip resource does not change but its
allocation does. The output are stale until the next time terraform
plans.