### PR TITLE
Use rendered attribute of ignition resources

### DIFF
--- a/terraform/ignition/ignition.tf
+++ b/terraform/ignition/ignition.tf
@@ -28,10 +28,10 @@ data "ignition_config" "wiresteward" {
   count = local.instance_count
 
   files = concat([
-    data.ignition_file.wiresteward_config[count.index].id,
+    data.ignition_file.wiresteward_config[count.index].rendered,
   ], var.additional_ignition_files)
 
   systemd = concat([
-    data.ignition_systemd_unit.wiresteward_service.id,
+    data.ignition_systemd_unit.wiresteward_service.rendered,
   ], var.additional_systemd_units)
 }


### PR DESCRIPTION
```
Error: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'f' after top-level value

  on .terraform/modules/wiresteward_ignition/terraform/ignition/ignition.tf line 27, in data "ignition_config" "wiresteward":
  27: data "ignition_config" "wiresteward" {
```