### PR TITLE
Add kernel-based implementation for agent

### DIFF
--- a/device.go
+++ b/device.go
@@ -20,6 +20,12 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+type AgentDevice interface {
+	Name() string
+	Run() error
+	Stop()
+}
+
 // TunDevice represents a tun network device on the system, setup for use with
 // user space wireguard. This is utilised by the agent-side wiresteward, to
 // provide a cross-platform implementation basd on wireguard-go.

--- a/devicemanager.go
+++ b/devicemanager.go
@@ -28,8 +28,14 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string) *Dev
 	for _, e := range wirestewardURLs {
 		config[e] = nil
 	}
+	var device AgentDevice
+	if *flagDeviceType == "wireguard" {
+		device = newWireguardDevice(deviceName, mtu)
+	} else {
+		device = newTunDevice(deviceName, mtu)
+	}
 	return &DeviceManager{
-		AgentDevice: newTunDevice(deviceName, mtu),
+		AgentDevice: device,
 		config:      config,
 	}
 }

--- a/devicemanager.go
+++ b/devicemanager.go
@@ -12,11 +12,11 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-// DeviceManager embeds a TunDevice and implements functionality related to
+// DeviceManager embeds an AgentDevice and implements functionality related to
 // configuring the device and system based on information retrieved from
 // wiresteward servers.
 type DeviceManager struct {
-	*TunDevice
+	AgentDevice
 	configMutex sync.Mutex
 	// config maps a wiresteward server url to a running configuration. It is
 	// used to cleanup running configuration before applying a new one.
@@ -29,15 +29,15 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string) *Dev
 		config[e] = nil
 	}
 	return &DeviceManager{
-		TunDevice: newTunDevice(deviceName, mtu),
-		config:    config,
+		AgentDevice: newTunDevice(deviceName, mtu),
+		config:      config,
 	}
 }
 
-// Run starts the TunDevice by calling its Run() method and proceeds to
+// Run starts the AgentDevice by calling its Run() method and proceeds to
 // initialise it.
 func (dm *DeviceManager) Run() error {
-	if err := dm.TunDevice.Run(); err != nil {
+	if err := dm.AgentDevice.Run(); err != nil {
 		return fmt.Errorf("Error starting tun device `%s`: %w", dm.Name(), err)
 	}
 	if err := dm.ensureLinkUp(); err != nil {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -18,6 +19,7 @@ var (
 	builtBy         = "unknown"
 	flagAgent       = flag.Bool("agent", false, "Run application in \"agent\" mode")
 	flagConfig      = flag.String("config", "/etc/wiresteward/config.json", "Config file")
+	flagDeviceType  = flag.String("device-type", "tun", "Type of the network device to use for the agent, 'tun' or 'wireguard'.\nThe tun device relies on the wireguard-go userspace implementation that is compatible with all platforms.\nA wireguard device relies on wireguard-enabled linux kernels (5.6 or newer).")
 	flagLogLevel    = flag.String("log-level", "info", "Log Level (debug|info|error)")
 	flagMetricsAddr = flag.String("metrics-address", ":8081", "Metrics server address, meaningful when combined with -server flag")
 	flagServer      = flag.Bool("server", false, "Run application in \"server\" mode")
@@ -43,6 +45,11 @@ func main() {
 		logger.Error.Fatalln(
 			"Must only set -agent or -server, not both",
 		)
+	}
+
+	*flagDeviceType = strings.ToLower(*flagDeviceType)
+	if *flagDeviceType != "tun" && *flagDeviceType != "wireguard" {
+		logger.Error.Fatalf("Invalid device-type value `%s`", *flagDeviceType)
 	}
 
 	if *flagAgent {

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func server() {
 		logger.Error.Fatalf("Cannot read server config: %v", err)
 	}
 
-	wg := newWireguardDevice(cfg)
+	wg := newServerDevice(cfg)
 	if err := wg.Start(); err != nil {
 		logger.Error.Fatalf(
 			"Cannot setup wireguard device '%s': %v",


### PR DESCRIPTION
Set `WIRESTEWARD_USE_KERNEL_WIREGUARD` to a non-empty value to enable this experimental behaviour.