### PR TITLE
Fix cleanup of devices on error

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -74,7 +74,7 @@ func (a *Agent) ListenAndServe() {
 	// 7773 is chosen by looking wiresteward initials hex on ascii table
 	// (w = 0x77 and s = 0x73)
 	if err := http.ListenAndServe("127.0.0.1:7773", nil); err != nil {
-		logger.Error.Fatal(err)
+		logger.Error.Println(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -139,12 +139,16 @@ func agent() {
 		logger.Error.Fatalf("Cannot read agent config: %v", err)
 	}
 
-	agent := NewAgent(agentConf)
-	go agent.ListenAndServe()
-
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt)
+
+	agent := NewAgent(agentConf)
+	go func() {
+		agent.ListenAndServe()
+		close(term)
+	}()
+
 	select {
 	case <-term:
 	}


### PR DESCRIPTION
When using wireguard devices, these will not get cleaned up when the
agent dies.
