### PR TITLE
PoC: Introduces a multipath flag

### DIFF
--- a/devicemanager.go
+++ b/devicemanager.go
@@ -20,10 +20,11 @@ type DeviceManager struct {
 	configMutex sync.Mutex
 	// config maps a wiresteward server url to a running configuration. It is
 	// used to cleanup running configuration before applying a new one.
-	config map[string]*WirestewardPeerConfig
+	config    map[string]*WirestewardPeerConfig
+	multipath bool
 }
 
-func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string) *DeviceManager {
+func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string, multipath bool) *DeviceManager {
 	config := make(map[string]*WirestewardPeerConfig, len(wirestewardURLs))
 	for _, e := range wirestewardURLs {
 		config[e] = nil
@@ -37,6 +38,7 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string) *Dev
 	return &DeviceManager{
 		AgentDevice: device,
 		config:      config,
+		multipath:   multipath,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	flagDeviceType   *string
 	flagLogLevel     = flag.String("log-level", "info", "Log Level (debug|info|error)")
 	flagMetricsAddr  = flag.String("metrics-address", ":8081", "Metrics server address, meaningful when combined with -server flag")
+	flagMultipath    = flag.Bool("multipath", false, "Agent will use multipaths instead of gateway for configuring route tables")
 	flagServer       = flag.Bool("server", false, "Run application in \"server\" mode")
 	flagVersion      = flag.Bool("version", false, "Prints out application version")
 )
@@ -159,7 +160,7 @@ func agent() {
 	signal.Notify(term, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt)
 
-	agent := NewAgent(agentConf)
+	agent := NewAgent(agentConf, *flagMultipath)
 	go func() {
 		agent.ListenAndServe()
 		close(term)

--- a/route_map.go
+++ b/route_map.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/vishvananda/netlink"
+	"net"
+)
+
+// A map of cidr to multipath hops
+var routeMap = make(map[string][]*netlink.NexthopInfo)
+
+// applyMap creates a netlink route for all the entries in the routeMap map
+func applyMap() {
+	h := netlink.Handle{}
+	defer h.Delete()
+	for d, mp := range routeMap {
+		_, dst, err := net.ParseCIDR(d)
+		if err != nil {
+			logger.Error.Printf("Could not parse dst cidr: %s", err)
+		}
+		if err = h.RouteAdd(&netlink.Route{
+			Dst:       dst,
+			MultiPath: mp,
+		}); err != nil {
+			logger.Error.Printf(
+				"Could not add new route (%s): %s", dst, err)
+		}
+	}
+}


### PR DESCRIPTION
Multipath flag will instruct the agent to keep a route map instead of adding
routes when configuring devices and the agent could flush the route map in the
route table after setting all devices.

etc:
```
10.22.0.0/16 via 10.90.48.12 dev wg1
10.33.0.0/16 via 10.90.160.12 dev wg4
10.44.0.0/16 via 10.90.128.8 dev wg3
10.66.0.0/16 via 10.90.0.9 dev wg0
10.88.0.0/16
        nexthop via 10.90.64.3 dev wg2 weight 1
        nexthop via 10.90.80.3 dev wg6 weight 1
10.89.0.0/16 via 10.90.208.6 dev wg5
10.90.64.1 via 10.90.64.3 dev wg2
10.91.0.0/16 via 10.90.208.6 dev wg5
10.93.0.0/16 via 10.90.208.6 dev wg5
```