### PR TITLE
Clamp mss to pmtu for agent running on Linux

### DIFF
--- a/examples/wiresteward.service
+++ b/examples/wiresteward.service
@@ -4,6 +4,8 @@ After=network-online.target
 Requires=network-online.target
 [Service]
 Restart=on-failure
+ExecStartPre=/bin/sh -c 'iptables-save | grep -q -- "-A POSTROUTING -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu" \
+  || iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu'
 ExecStart=/usr/local/bin/wiresteward -agent
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://www.linuxtopia.org/Linux_Firewall_iptables/x4700.html#:~:text=The%20%2D%2Dclamp%2Dmss%2Dto,reasonable%20value%20for%20most%20applications.

Applications that are running on the host already do this via default
`advmss`:

> If it is not given, Linux uses a default value calculated from the
> first hop device MTU.

From: https://www.systutorials.com/docs/linux/man/8-ip-route/

OpenWRT thread on why set this in POSTROUTING:
https://openwrt-devel.openwrt.narkive.com/1ikg7NtX/mss-clamping-in-postrouting-instead-of-forward

`--clamp-mss-to-pmtu` as a "fix" for routing problems:
https://tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html
