### PR TITLE
Prepare terraform form aws/gcp v0.2.0

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -29,6 +29,20 @@ resource "aws_security_group" "wiresteward" {
   }
 
   ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     from_port   = 51820
     to_port     = 51820
     protocol    = "udp"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -81,6 +81,19 @@ resource "google_compute_firewall" "wiresteward-udp" {
   target_tags   = [local.name]
 }
 
+resource "google_compute_firewall" "wiresteward-tcp" {
+  name      = "${local.name}-tcp"
+  network   = var.vpc_link
+  direction = "INGRESS"
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = [local.name]
+}
+
 //https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules
 resource "google_compute_firewall" "wiresteward-healthcheck" {
   name    = "${local.name}-healthcheck"

--- a/terraform/ignition/io.tf
+++ b/terraform/ignition/io.tf
@@ -38,7 +38,7 @@ variable "wireguard_exposed_subnets" {
 variable "wiresteward_version" {
   type        = string
   description = "The version of wiresteward to deploy (see https://github.com/utilitywarehouse/wiresteward/)"
-  default     = "0.2.0-rc.2"
+  default     = "0.2.0-rc.3"
 }
 
 variable "traefik_image" {

--- a/terraform/ignition/resources/wiresteward-config.json.tmpl
+++ b/terraform/ignition/resources/wiresteward-config.json.tmpl
@@ -3,6 +3,5 @@
   "allowedIPs": ${jsonencode(wireguard_exposed_subnets)},
   "endpoint": "${wireguard_endpoint}:51820",
   "oauthIntrospectUrl": "${oauth2_introspect_url}",
-  "oauthClientId": "${oauth2_client_id}",
-  "serverListenAddress": "127.0.0.1:8080"
+  "oauthClientId": "${oauth2_client_id}"
 }


### PR DESCRIPTION
- Change firewall to allow public traffic on http ports to reach traefik
- Remove the local server listen address from the config to allow both the old
  and new setups to work. This should be re-added when we delete the load
  balancers in front of the instances.