### PR TITLE
tf/matchbox: move DNS configuration to resolved.conf

### DIFF
--- a/terraform/matchbox/dns.tf
+++ b/terraform/matchbox/dns.tf
@@ -1,0 +1,12 @@
+data "ignition_file" "resolved_conf" {
+  filesystem = "root"
+  path       = "/etc/systemd/resolved.conf"
+  mode       = 420
+
+  content {
+    content = <<-EOF
+[Resolve]
+DNS=${join(" ", var.dns_nameservers)}
+EOF
+  }
+}

--- a/terraform/matchbox/main.tf
+++ b/terraform/matchbox/main.tf
@@ -65,6 +65,7 @@ data "ignition_config" "wiresteward" {
     list(
       data.ignition_file.hostname[count.index].rendered,
       data.ignition_file.iptables_rules[count.index].rendered,
+      data.ignition_file.resolved_conf.rendered,
     ),
     var.ignition_files[count.index],
   )

--- a/terraform/matchbox/net.tf
+++ b/terraform/matchbox/net.tf
@@ -64,7 +64,6 @@ MTUBytes=9000
 MACAddress=${var.wiresteward_server_peers[count.index].mac_addresses[0]}
 [Network]
 DHCP=no
-DNS=1.1.1.1
 VLAN=bond0.${var.private_vlan_id}
 VLAN=bond0.${var.public_vlan_id}
 EOS

--- a/terraform/matchbox/variables.tf
+++ b/terraform/matchbox/variables.tf
@@ -77,3 +77,12 @@ variable "wiresteward_metrics_port" {
   description = "Port to scrape wiresteward metrics"
   default     = "8081"
 }
+
+variable "dns_nameservers" {
+  type        = list(string)
+  description = "A list of DNS servers"
+  default = [
+    "1.1.1.1",
+    "1.0.0.1",
+  ]
+}


### PR DESCRIPTION
The latest releases of Flatcar stable enable the systemd-resolved stub resolver. Although I'm not sure why, this seems to ignore the DNS server set on the link (even though systemd-resolved does properly populate resolv.conf with it).

This commit sets the DNS server globally in /etc/systemd/resolved.conf. It also adds the other Cloudflare DNS address 1.0.0.1 which we're providing via DHCP on other instances.

I've made the nameservers configurable too, to avoid having to edit the module if we want to change this in future.