### PR TITLE
Add a default configurable timeout on agent http client

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -29,7 +29,7 @@ func NewAgent(cfg *agentConfig) *Agent {
 		for _, peer := range dev.Peers {
 			urls = append(urls, peer.URL)
 		}
-		dm := newDeviceManager(dev.Name, dev.MTU, urls)
+		dm := newDeviceManager(dev.Name, dev.MTU, urls, cfg.HTTPClient.Timeout)
 		if err := dm.Run(); err != nil {
 			logger.Error.Printf(
 				"Error starting device `%s`: %v",
@@ -102,8 +102,8 @@ func (a *Agent) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	a.renewAllLeases(token.AccessToken)
 	// Redirect to / after renewing leases
-	rootUrl := fmt.Sprintf("http://%s/", r.Host)
-	http.Redirect(w, r, rootUrl, 302)
+	rootURL := fmt.Sprintf("http://%s/", r.Host)
+	http.Redirect(w, r, rootURL, 302)
 }
 
 func (a *Agent) renewHandler(w http.ResponseWriter, r *http.Request) {
@@ -126,8 +126,8 @@ func (a *Agent) renewHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	a.renewAllLeases(token.AccessToken)
 	// Redirect to / after renewing leases
-	rootUrl := fmt.Sprintf("http://%s/", r.Host)
-	http.Redirect(w, r, rootUrl, 302)
+	rootURL := fmt.Sprintf("http://%s/", r.Host)
+	http.Redirect(w, r, rootURL, 302)
 }
 
 func (a *Agent) mainHandler(w http.ResponseWriter, r *http.Request) {

--- a/config_test.go
+++ b/config_test.go
@@ -35,6 +35,11 @@ func TestAgentConfigFmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = verifyAgentHTTPClientConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, conf.HTTPClient.Timeout, defaultAgentHTTPClientTimeout)
 
 	devicesOnly := []byte(`
 {
@@ -71,6 +76,11 @@ func TestAgentConfigFmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = verifyAgentHTTPClientConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, conf.HTTPClient.Timeout, defaultAgentHTTPClientTimeout)
 
 	full := []byte(`
 {
@@ -89,7 +99,10 @@ func TestAgentConfigFmt(t *testing.T) {
         }
       ]
     }
-  ]
+  ],
+  "httpclient": {
+    "timeout": "5s"
+  }
 }
 `)
 
@@ -115,6 +128,11 @@ func TestAgentConfigFmt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = verifyAgentHTTPClientConfig(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, conf.HTTPClient.Timeout, "5s")
 }
 
 func TestServerConfig(t *testing.T) {


### PR DESCRIPTION
Observed that when rolling wiresteward servers, the agent can stuck while trying
to hit a server that is unavailable. This introduces a timeout on the agent's
http client, so requests can terminate faster, giving better failover times