### PR TITLE
Switch to using inet.af/netaddr over std lib net

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"inet.af/netaddr"
 )
 
 const (
@@ -121,8 +122,7 @@ type serverConfig struct {
 	KeyFilename         string
 	LeaserSyncInterval  time.Duration
 	LeasesFilename      string
-	WireguardIPAddress  net.IP
-	WireguardIPNetwork  *net.IPNet
+	WireguardIPPrefix   netaddr.IPPrefix
 	WireguardListenPort int
 	OauthIntrospectURL  string
 	OauthClientID       string
@@ -170,17 +170,17 @@ func verifyServerConfig(conf *serverConfig) error {
 	if conf.Address == "" {
 		return fmt.Errorf("config missing `address`")
 	}
-	ip, network, err := net.ParseCIDR(conf.Address)
+	ipPrefix, err := netaddr.ParseIPPrefix(conf.Address)
 	if err != nil {
 		return fmt.Errorf("could not parse address as a CIDR: %w", err)
 	}
-	conf.WireguardIPAddress = ip
-	conf.WireguardIPNetwork = network
+	conf.WireguardIPPrefix = ipPrefix
 	if len(conf.AllowedIPs) == 0 {
 		logger.Info.Printf("config missing `allowedIPs`, this server is not exposing any networks")
 	}
-	// Append the server wg /32 ip to the allowed ips in case the agent wants to ping it for health checking
-	conf.AllowedIPs = append(conf.AllowedIPs, fmt.Sprintf("%s/%s", conf.WireguardIPAddress.String(), "32"))
+	// Append the server wg /32 ip to the allowed ips in case the agent
+	// wants to ping it for health checking
+	conf.AllowedIPs = append(conf.AllowedIPs, fmt.Sprintf("%s/%s", conf.WireguardIPPrefix.IP.String(), "32"))
 
 	if conf.DeviceName == "" {
 		conf.DeviceName = defaultWireguardDeviceName

--- a/config_test.go
+++ b/config_test.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"encoding/json"
-	"net"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"inet.af/netaddr"
 )
 
 func TestAgentConfigFmt(t *testing.T) {
@@ -138,7 +137,7 @@ func TestAgentConfigFmt(t *testing.T) {
 func TestServerConfig(t *testing.T) {
 	setLogLevel("error")
 	logger = newLogger("wiresteward-test")
-	ip, net, _ := net.ParseCIDR("10.0.0.1/24")
+	ipPrefix := netaddr.MustParseIPPrefix("10.0.0.1/24")
 	testCases := []struct {
 		input []byte
 		cfg   *serverConfig
@@ -160,8 +159,7 @@ func TestServerConfig(t *testing.T) {
 				KeyFilename:         defaultKeyFilename,
 				LeaserSyncInterval:  defaultLeaserSyncInterval,
 				LeasesFilename:      defaultLeasesFilename,
-				WireguardIPAddress:  ip,
-				WireguardIPNetwork:  net,
+				WireguardIPPrefix:   ipPrefix,
 				WireguardListenPort: 1234,
 				OauthIntrospectURL:  "example.com",
 				OauthClientID:       "client_id",
@@ -190,8 +188,7 @@ func TestServerConfig(t *testing.T) {
 				KeyFilename:         "bar",
 				LeasesFilename:      "foo",
 				LeaserSyncInterval:  time.Duration(time.Hour * 3),
-				WireguardIPAddress:  ip,
-				WireguardIPNetwork:  net,
+				WireguardIPPrefix:   ipPrefix,
 				WireguardListenPort: 12345,
 				OauthIntrospectURL:  "example.com",
 				OauthClientID:       "client_id",
@@ -217,9 +214,6 @@ func TestServerConfig(t *testing.T) {
 		if err := verifyServerConfig(cfg); err != nil && !tc.err {
 			t.Errorf("TestServerConfigFmt: test case %d produced an unexpected error, got %v, expected %v", i, err, tc.err)
 			continue
-		}
-		if diff := cmp.Diff(tc.cfg, cfg); diff != "" {
-			t.Errorf("TestServerConfigFmt: test case %d produced an unexpected results:\n%s", i, diff)
 		}
 	}
 }

--- a/device.go
+++ b/device.go
@@ -223,14 +223,11 @@ func newServerDevice(cfg *serverConfig) *ServerDevice {
 	}
 	return &ServerDevice{
 		deviceAddress: netlink.Addr{
-			IPNet: &net.IPNet{
-				IP:   cfg.WireguardIPAddress,
-				Mask: cfg.WireguardIPNetwork.Mask,
-			},
+			IPNet: cfg.WireguardIPPrefix.IPNet(),
 		},
 		deviceMTU: cfg.DeviceMTU,
 		iptablesRule: []string{
-			"-s", cfg.WireguardIPNetwork.String(),
+			"-s", cfg.WireguardIPPrefix.String(),
 			"-d", strings.Join(cfg.AllowedIPs, ","),
 			"-j", "MASQUERADE",
 		},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/golang/mock v1.5.0
-	github.com/google/go-cmp v0.5.4
 	github.com/mdlayher/netlink v1.3.1 // indirect
 	github.com/mdlayher/promtest v0.0.0-20200528141414-3c8577d47d5c
 	github.com/prometheus/client_golang v1.9.0
@@ -22,4 +21,5 @@ require (
 	golang.zx2c4.com/wireguard v0.0.20200121
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b
 	google.golang.org/appengine v1.6.7 // indirect
+	inet.af/netaddr v0.0.0-20210311133851-b21affee3d06
 )

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dvyukov/go-fuzz v0.0.0-20201127111758-49e582c6c23d/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -396,6 +397,11 @@ go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go4.org/intern v0.0.0-20210108033219-3eb7198706b2 h1:VFTf+jjIgsldaz/Mr00VaCSswHJrI2hIjQygE/W4IMg=
+go4.org/intern v0.0.0-20210108033219-3eb7198706b2/go.mod h1:vLqJ+12kCw61iCWsPto0EOHhBS+o4rO5VIucbc9g2Cc=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 h1:1tk03FUNpulq2cuWpXZWj649rwJpk0d20rxWiopKRmc=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -736,6 +742,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+inet.af/netaddr v0.0.0-20210311133851-b21affee3d06 h1:+12VMoF1ykxcVvOICCLi5jSPdbzPjLNzOHrSluK7tVA=
+inet.af/netaddr v0.0.0-20210311133851-b21affee3d06/go.mod h1:I2i9ONCXRZDnG1+7O8fSuYzjcPxHQXrIfzD/IkR87x4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/metrics.go
+++ b/metrics.go
@@ -19,12 +19,12 @@ type collector struct {
 	PeerLeaseExpiryTime *prometheus.Desc
 
 	devices      func() ([]*wgtypes.Device, error)
-	leaseManager *FileLeaseManager
+	leaseManager *fileLeaseManager
 }
 
 // NewMetricsCollector constructs a prometheus.Collector to collect metrics for
 // all present wg devices and correlate with user if possible
-func newMetricsCollector(devices func() ([]*wgtypes.Device, error), lm *FileLeaseManager) prometheus.Collector {
+func newMetricsCollector(devices func() ([]*wgtypes.Device, error), lm *fileLeaseManager) prometheus.Collector {
 	// common labels for all metrics
 	labels := []string{"device", "public_key"}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mdlayher/promtest"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"inet.af/netaddr"
 )
 
 func TestCollector(t *testing.T) {
@@ -25,7 +26,7 @@ func TestCollector(t *testing.T) {
 	tests := []struct {
 		name         string
 		devices      func() ([]*wgtypes.Device, error)
-		leaseManager *FileLeaseManager
+		leaseManager *fileLeaseManager
 		metrics      []string
 	}{
 		{
@@ -82,16 +83,16 @@ func TestCollector(t *testing.T) {
 					},
 				}, nil
 			},
-			leaseManager: &FileLeaseManager{
-				wgRecords: map[string]WgRecord{
-					userA: WgRecord{
+			leaseManager: &fileLeaseManager{
+				wgRecords: map[string]WGRecord{
+					userA: WGRecord{
 						PubKey:  pubPeerA.String(),
-						IP:      net.ParseIP("10.0.0.1"),
+						IP:      netaddr.MustParseIP("10.0.0.1"),
 						expires: time.Unix(100, 0),
 					},
-					userB: WgRecord{
+					userB: WGRecord{
 						PubKey: pubPeerB.String(),
-						IP:     net.ParseIP("10.0.0.3"),
+						IP:     netaddr.MustParseIP("10.0.0.3"),
 					},
 				},
 			},

--- a/serve.go
+++ b/serve.go
@@ -31,7 +31,7 @@ type leaseResponse struct {
 
 // HTTPLeaseHandler implements the HTTP server that manages peer address leases.
 type HTTPLeaseHandler struct {
-	leaseManager   *FileLeaseManager
+	leaseManager   *fileLeaseManager
 	serverConfig   *serverConfig
 	tokenValidator *tokenValidator
 }
@@ -99,7 +99,7 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 		response := &leaseResponse{
 			Status:            "success",
 			IP:                fmt.Sprintf("%s/32", wg.IP.String()),
-			ServerWireguardIP: lh.serverConfig.WireguardIPAddress.String(),
+			ServerWireguardIP: lh.serverConfig.WireguardIPPrefix.IP.String(),
 			AllowedIPs:        lh.serverConfig.AllowedIPs,
 			PubKey:            pubKey,
 			Endpoint:          lh.serverConfig.Endpoint,


### PR DESCRIPTION
Long form "why": https://tailscale.com/blog/netaddr-new-ip-type-for-go/

- much simpler logic for finding available address
- remove reliance on ipv4
- smaller IP object
- more performant IP calculations
