### PR TITLE
Use two intervals for healthchecking

### DIFF
--- a/agent_http.go
+++ b/agent_http.go
@@ -144,7 +144,7 @@ func statusHTTPWriter(w http.ResponseWriter, r *http.Request, deviceManagers []*
 					Dst:             ip.String(),
 					GW:              dm.config.LocalAddress.String(),
 					IsHealthChecked: dm.isHealthChecked(),
-					Healthy:         dm.isHealthy(),
+					Healthy:         dm.healthCheck.healthy,
 				}
 				routes = append(routes, r)
 			}

--- a/config.go
+++ b/config.go
@@ -20,9 +20,10 @@ const (
 )
 
 var (
-	defaultAgentHTTPClientTimeout   = Duration{3 * time.Second}
-	defaultAgentHealthCheckInterval = Duration{time.Second}
-	defaultAgentHealthCheckTimeout  = Duration{time.Second}
+	defaultAgentHTTPClientTimeout               = Duration{3 * time.Second}
+	defaultAgentHealthCheckInterval             = Duration{10 * time.Second}
+	defaultAgentHealthCheckIntervalAfterFailure = Duration{time.Second}
+	defaultAgentHealthCheckTimeout              = Duration{time.Second}
 )
 
 // agentOAuthConfig encapsulates agent-side OAuth configuration for wiresteward
@@ -59,15 +60,17 @@ var defaultAgentHTTPClientConfig = agentHTTPClientConfig{
 // agentHealthcheckConfig contains the global config for all the healthchecks
 // created by the agent against server peers.
 type agentHealthCheckConfig struct {
-	Interval  Duration `json:"interval"`
-	Threshold int      `json:"threshold"`
-	Timeout   Duration `json:"timeout"`
+	Interval             Duration `json:"interval"`
+	IntervalAfterFailure Duration `json:"intervalAF"`
+	Threshold            int      `json:"threshold"`
+	Timeout              Duration `json:"timeout"`
 }
 
 var dedfaultAgentHealthCheckConfig = agentHealthCheckConfig{
-	Interval:  defaultAgentHealthCheckInterval,
-	Threshold: defaultAgentHealthCheckThreshold,
-	Timeout:   defaultAgentHealthCheckTimeout,
+	Interval:             defaultAgentHealthCheckInterval,
+	IntervalAfterFailure: defaultAgentHealthCheckIntervalAfterFailure,
+	Threshold:            defaultAgentHealthCheckThreshold,
+	Timeout:              defaultAgentHealthCheckTimeout,
 }
 
 // AgentConfig describes the agent-side configuration of wiresteward.

--- a/devicemanager.go
+++ b/devicemanager.go
@@ -50,10 +50,6 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string, http
 	}
 }
 
-func (dm *DeviceManager) isHealthy() bool {
-	return dm.healthCheck.isHealthy()
-}
-
 func (dm *DeviceManager) isHealthChecked() bool {
 	return len(dm.serverURLs) > 1
 }
@@ -183,6 +179,7 @@ func (dm *DeviceManager) renewLease() error {
 		hc, err := newHealthCheck(
 			wgServerAddr,
 			dm.healthCheckConf.Interval,
+			dm.healthCheckConf.IntervalAfterFailure,
 			dm.healthCheckConf.Timeout,
 			dm.healthCheckConf.Threshold,
 			dm.renewLeaseChan,

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -11,7 +11,13 @@ import (
 )
 
 func TestHealthcheck_NewHealthCheck(t *testing.T) {
-	hc, err := newHealthCheck("10.0.0.0", Duration{time.Second}, Duration{time.Second}, 3, make(chan struct{}))
+	hc, err := newHealthCheck(
+		"10.0.0.0",
+		Duration{10 * time.Second},
+		Duration{time.Second},
+		Duration{time.Second},
+		3,
+		make(chan struct{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +32,13 @@ func TestHealthcheck_RunConsecutiveFails(t *testing.T) {
 	mockChecker := mocks.NewMockchecker(ctrl)
 
 	renewNotify := make(chan struct{})
-	hc, err := newHealthCheck("10.0.0.0", Duration{100 * time.Millisecond}, Duration{time.Second}, 3, renewNotify)
+	hc, err := newHealthCheck(
+		"10.0.0.0",
+		Duration{100 * time.Millisecond},
+		Duration{10 * time.Millisecond},
+		Duration{time.Second},
+		3,
+		renewNotify)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +69,13 @@ func TestHealthcheck_RunHealthyCheckResets(t *testing.T) {
 	mockChecker := mocks.NewMockchecker(ctrl)
 
 	renewNotify := make(chan struct{})
-	hc, err := newHealthCheck("10.0.0.0", Duration{100 * time.Millisecond}, Duration{time.Second}, 3, renewNotify)
+	hc, err := newHealthCheck(
+		"10.0.0.0",
+		Duration{100 * time.Millisecond},
+		Duration{10 * time.Millisecond},
+		Duration{time.Second},
+		3,
+		renewNotify)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A larger one for "healthy" checking. After the first failure - go down
to 1s.

That means by default we check every 10s. If a healthcheck fails, we
reset the ticker to 1s, and continue checking.

After 3 failures we failover (13s max, 8s average).

If instead we get a healthy check - reset the "unhealthyCount" and reset
the ticker, back to 10s interval.

Compared to previous implementation - our average failover time goes up
from 3.5s to 8s, ~2.3x increase. But our healthcheck load decreases 10x,
from 1s to 10s.
