### PR TITLE
Check if tokens are expired before further actions.

### DIFF
--- a/devicemanager.go
+++ b/devicemanager.go
@@ -127,6 +127,13 @@ func (dm *DeviceManager) renewLease() error {
 	if dm.cachedToken == "" {
 		return fmt.Errorf("Empty cached token")
 	}
+	t, err := parseToken(dm.cachedToken)
+	if err != nil {
+		return fmt.Errorf("Cannot unmarshal cached token: %v", err)
+	}
+	if t.Expiry.Before(time.Now()) {
+		return fmt.Errorf("Cached token is expired")
+	}
 	publicKey, _, err := getKeys(dm.Name())
 	if err != nil {
 		return fmt.Errorf("Could not get keys from device %s: %w", dm.Name(), err)

--- a/oauth2.go
+++ b/oauth2.go
@@ -218,9 +218,9 @@ func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionR
 }
 
 // parseToken takes a string and unmarshals to an oauth2 Token
-func parseToken(stringToken string) (*oauth2.Token, error) {
+func parseToken(t string) (*oauth2.Token, error) {
 	tok := &oauth2.Token{}
-	err := json.Unmarshal([]byte(stringToken), tok)
+	err := json.Unmarshal([]byte(t), tok)
 	if err != nil {
 		return tok, err
 	}


### PR DESCRIPTION
- Agent avoids requesting a new lease with an expired token
- server avoids requests to the introspection endpoint for expired tokens.