### PR TITLE
aws: retrieve userdata from s3

### DIFF
--- a/terraform/aws/io.tf
+++ b/terraform/aws/io.tf
@@ -40,9 +40,25 @@ variable "wiresteward_endpoint" {
   description = "The endpoint for wiresteward where clients connect."
 }
 
+variable "iam_prefix" {
+  description = "prefix to be added to iam resources names"
+  default     = ""
+}
+
+variable "permissions_boundary" {
+  description = "permission_boudnary to apply to iam resources"
+  default     = ""
+}
+
+variable "bucket_prefix" {
+  description = "prefix to be added to the userdata bucket"
+  default     = ""
+}
+
 locals {
   instance_count = length(var.ignition)
   name           = var.role_name
+  iam_prefix     = "${var.iam_prefix}${var.iam_prefix == "" ? "" : "-"}"
 }
 
 output "public_ipv4_addresses" {

--- a/terraform/aws/io.tf
+++ b/terraform/aws/io.tf
@@ -46,7 +46,7 @@ variable "iam_prefix" {
 }
 
 variable "permissions_boundary" {
-  description = "permission_boudnary to apply to iam resources"
+  description = "permissions_boundary to apply to iam resources"
   default     = ""
 }
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -87,7 +87,8 @@ resource "aws_instance" "peer" {
   vpc_security_group_ids = concat([aws_security_group.wiresteward.id], var.additional_security_group_ids)
   subnet_id              = var.subnet_ids[count.index]
   source_dest_check      = false
-  user_data              = var.ignition[count.index]
+  user_data              = data.template_file.userdata[count.index].rendered
+  iam_instance_profile   = aws_iam_instance_profile.peer.name
 
   lifecycle {
     ignore_changes = [ami]

--- a/terraform/aws/s3-userdata.tf
+++ b/terraform/aws/s3-userdata.tf
@@ -1,0 +1,82 @@
+# Store provided userdata in s3 bucket and provide a new one that fetches it
+
+resource "aws_s3_bucket" "userdata" {
+  bucket = "${var.bucket_prefix}-ignition-userdata-wiresteward"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "userdata" {
+  bucket = aws_s3_bucket.userdata.id
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
+resource "aws_s3_bucket_object" "userdata" {
+  count   = local.instance_count
+  bucket  = aws_s3_bucket.userdata.id
+  key     = "wiresteward-config-${count.index}-${sha1(var.ignition[count.index])}.json"
+  content = var.ignition[count.index]
+}
+
+data "template_file" "userdata" {
+  count   = local.instance_count
+  template = jsonencode(
+    {
+      ignition = {
+        version = "2.2.0",
+        config = {
+          replace = {
+            source = "s3://${aws_s3_bucket.userdata.id}/wiresteward-config-${count.index}-${sha1(var.ignition[count.index])}.json",
+            aws = {
+              region = "eu-west-1"
+            }
+          }
+        }
+      }
+    }
+  )
+}
+
+# Instance profile to allow fetching the userdata
+
+data "aws_iam_policy_document" "peer_auth" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "peer" {
+  name                 = "${local.iam_prefix}wiresteward-peer"
+  assume_role_policy   = data.aws_iam_policy_document.peer_auth.json
+  permissions_boundary = var.permissions_boundary
+}
+
+data "aws_iam_policy_document" "peer" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.userdata.id}/wiresteward-*"]
+  }
+}
+
+resource "aws_iam_role_policy" "peer" {
+  name   = "${local.iam_prefix}wiresteward-peer"
+  role   = aws_iam_role.peer.id
+  policy = data.aws_iam_policy_document.peer.json
+}
+
+resource "aws_iam_instance_profile" "peer" {
+  name = "${local.iam_prefix}wiresteward-peer"
+  role = aws_iam_role.peer.name
+}


### PR DESCRIPTION
Userdata from an aws instance can be retrieved with "DescribeInstance",
which is a fairly common "read only" permission. By storing the userdata
in s3 we are not exposing the sensitive values