### PR TITLE
Change on-prem matchbox module net setup and allow disks

### DIFF
--- a/terraform/matchbox/main.tf
+++ b/terraform/matchbox/main.tf
@@ -8,6 +8,16 @@ data "ignition_disk" "sda" {
   }
 }
 
+data "ignition_disk" "nvme" {
+  device     = "/dev/nvme0n1"
+  wipe_table = true
+
+  partition {
+    label  = "ROOT"
+    number = 1
+  }
+}
+
 data "ignition_filesystem" "root" {
   name = "ROOT"
 
@@ -36,7 +46,7 @@ data "ignition_config" "wiresteward" {
   count = length(var.wiresteward_server_peers)
 
   disks = [
-    data.ignition_disk.sda.rendered,
+    var.wiresteward_server_peers[count.index].disk_type == "nvme" ? data.ignition_disk.nvme.rendered : data.ignition_disk.sda.rendered,
   ]
 
   filesystems = [
@@ -46,10 +56,8 @@ data "ignition_config" "wiresteward" {
   networkd = [
     data.ignition_networkd_unit.bond_net_eno.rendered,
     data.ignition_networkd_unit.bond_netdev.rendered,
-    data.ignition_networkd_unit.bond_private_vlan_netdev[count.index].rendered,
     data.ignition_networkd_unit.bond_public_vlan_netdev[count.index].rendered,
     data.ignition_networkd_unit.bond0[count.index].rendered,
-    data.ignition_networkd_unit.bond0_private_vlan[count.index].rendered,
     data.ignition_networkd_unit.bond0_public_vlan[count.index].rendered,
 
   ]

--- a/terraform/matchbox/net.tf
+++ b/terraform/matchbox/net.tf
@@ -24,20 +24,6 @@ Mode=802.3ad
 EOS
 }
 
-data "ignition_networkd_unit" "bond_private_vlan_netdev" {
-  count = length(var.wiresteward_server_peers)
-
-  name    = "11-bond-private-vlan.netdev"
-  content = <<EOS
-[NetDev]
-Name=bond0.${var.private_vlan_id}
-Kind=vlan
-
-[VLAN]
-Id=${var.private_vlan_id}
-EOS
-}
-
 data "ignition_networkd_unit" "bond_public_vlan_netdev" {
   count = length(var.wiresteward_server_peers)
 
@@ -64,21 +50,7 @@ MTUBytes=9000
 MACAddress=${var.wiresteward_server_peers[count.index].mac_addresses[0]}
 [Network]
 DHCP=no
-VLAN=bond0.${var.private_vlan_id}
 VLAN=bond0.${var.public_vlan_id}
-EOS
-}
-
-data "ignition_networkd_unit" "bond0_private_vlan" {
-  count = length(var.wiresteward_server_peers)
-
-  name = "21-bond0-private-vlan.network"
-
-  content = <<EOS
-[Match]
-Name=bond0.${var.private_vlan_id}
-[Network]
-DHCP=no
 [Address]
 Address=${var.wiresteward_server_peers[count.index].private_ip_address}/24
 [Route]

--- a/terraform/matchbox/variables.tf
+++ b/terraform/matchbox/variables.tf
@@ -14,7 +14,6 @@ variable "flatcar_initrd_addresses" {
   description = "List of http endpoint locations the serve the flatcar initrd assets"
 }
 
-
 variable "ignition_files" {
   type        = list(list(string))
   description = "The ignition files configuration for the wiresteward instances. Output of the ignition module."
@@ -27,10 +26,6 @@ variable "ignition_systemd" {
 
 variable "matchbox_http_endpoint" {
   description = "http endpoint of matchbox server"
-}
-
-variable "private_vlan_id" {
-  description = "Vlan id of the wireguard instances' public network interfaces"
 }
 
 variable "private_vlan_gw" {
@@ -57,12 +52,20 @@ variable "wireguard_exposed_subnets" {
 
 variable "wiresteward_server_peers" {
   type = list(object({
+    disk_type          = string
     private_ip_address = string
     public_ip_address  = string
     wireguard_cidr     = string
     mac_addresses      = list(string)
   }))
   description = "The list of the wiresteweard server peers to create."
+
+  validation {
+    condition = alltrue([
+      for w in var.wiresteward_server_peers : contains(["sata", "nvme"], w.disk_type)
+    ])
+    error_message = "All wiresteward members must specify a disk type of either sata or nvme."
+  }
 }
 
 variable "ssh_address_range" {


### PR DESCRIPTION
- Allow wiresteward instances to specify disk types
- Opinionated change for network setup. Specify only public vlan interface and
assume that by default instance native vlan will be the private one. Works
better with moonshot 45XGc switches.