### PR TITLE
Exit retry loop if the token is expired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate-mocks test
+.PHONY: generate-mocks
 generate-mocks:
 	mkdir -p mocks
 	mockgen -source=ping.go -destination=mocks/mock_ping.go -package=mocks

--- a/oauth2.go
+++ b/oauth2.go
@@ -234,12 +234,12 @@ func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionR
 func validateJWTToken(t string) error {
 	tok, err := jwt.ParseSigned(t)
 	if err != nil {
-		return fmt.Errorf("Cannot parse JWT token: %v", err)
+		return err
 	}
 
 	cl := jwt.Claims{}
 	if err := tok.UnsafeClaimsWithoutVerification(&cl); err != nil {
-		return fmt.Errorf("Cannot unmarshal claims: %v", err)
+		return err
 	}
 
 	if cl.Expiry == nil {
@@ -249,7 +249,7 @@ func validateJWTToken(t string) error {
 	if err := cl.ValidateWithLeeway(jwt.Expected{
 		Time: time.Now(),
 	}, 0); err != nil {
-		return fmt.Errorf("Cannot validate JWT token: %v", err)
+		return err
 	}
 	return nil
 }

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -30,7 +30,7 @@ func TestValidateJWTToken(t *testing.T) {
 	}
 
 	err = validateJWTToken(tok)
-	expectedErr := fmt.Errorf("Cannot validate JWT token: %v", jwt.ErrExpired)
+	expectedErr := fmt.Errorf("%v", jwt.ErrExpired)
 	if err == nil {
 		t.Fatal("Validation of expired token did not fail")
 	}


### PR DESCRIPTION
Currently when token expires, wiresteward goes into generic backoff
retry loop, and keeps printing error logs for every device, saying that
the token is expired.

Wiresteward will never exit this condition on its own, and user needs to
renew the token.

If we get an error about expired token on renew, exit the loop and don't
retry.
