### PR TITLE
Make setting locksmithd systemd service optional

### DIFF
--- a/terraform/ignition/ignition.tf
+++ b/terraform/ignition/ignition.tf
@@ -90,9 +90,9 @@ data "ignition_config" "wiresteward" {
   ], var.additional_ignition_files)
 
   systemd = concat([
-    data.ignition_systemd_unit.locksmithd[count.index].rendered,
     data.ignition_systemd_unit.s3fs[count.index].rendered,
     data.ignition_systemd_unit.traefik.rendered,
     data.ignition_systemd_unit.wiresteward_service.rendered,
+    !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd[count.index].rendered : "",
   ], var.additional_systemd_units)
 }

--- a/terraform/ignition/io.tf
+++ b/terraform/ignition/io.tf
@@ -10,6 +10,11 @@ variable "additional_systemd_units" {
   default     = []
 }
 
+variable "omit_locksmithd_service" {
+  description = "Whether to omit locksmithd service from ignition. It should be used when passing locksmithd service as additional config to avoid ignition failures"
+  default     = false
+}
+
 variable "oauth2_introspect_url" {
   type        = string
   description = "Introspection url to validate access tokens"


### PR DESCRIPTION
Add ability to omit locksmithd service in case this is passed as an additional
ignition service. Ignition > 2.0.0 will mark the config as invalid if a service
is defined twice. Useful for our pxe setups.