### PR TITLE
homebrew release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
+          cache: true
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,13 +12,28 @@ builds:
       - mips
     gomips:
       - softfloat
+
 release:
   github:
     owner: utilitywarehouse
     name: wiresteward
+
 archives:
   - builds:
       - main
     format: binary
     files:
       - none*
+
+brews:
+  - name: wiresteward
+    description: Wireguard peer manager
+    license: MIT
+    folder: Formula
+    tap:
+      owner: utilitywarehouse
+      name: homebrew-tap
+    test:
+      system "#{bin}/wiresteward", "-version"
+    install: |-
+      bin.install "wiresteward"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,22 @@ brews:
     tap:
       owner: utilitywarehouse
       name: homebrew-tap
+    caveats: |
+      *********************
+      When running the agent via `brew services` place your config file at `/etc/wiresteward/config.json`
+      *********************
+      To start the agent run:
+        brew services start utilitywarehouse/tap/wiresteward
+      To stop the agent run:
+        brew services stop utilitywarehouse/tap/wiresteward
+      To restart the agent run:
+        brew services restart utilitywarehouse/tap/wiresteward
+      *********************
+      To uninstall the agent run the following commands:
+        brew services stop utilitywarehouse/tap/wiresteward
+        brew uninstall utilitywarehouse/tap/wiresteward
+        launchctl remove uk.co.uw.wiresteward
+      *********************
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-/Apple/DTD PLIST 1.0/EN" "http:/www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,36 @@ brews:
     tap:
       owner: utilitywarehouse
       name: homebrew-tap
-    test:
+    plist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-/Apple/DTD PLIST 1.0/EN" "http:/www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>uk.co.uw.wiresteward</string>
+
+          <key>KeepAlive</key>
+          <true/>
+
+          <key>RunAtLoad</key>
+          <true/>
+
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/wiresteward</string>
+            <string>-agent</string>
+          </array>
+
+          <key>StandardErrorPath</key>
+          <string>/var/log/wiresteward.err.log</string>
+
+          <key>StandardOutPath</key>
+          <string>/var/log/wiresteward.log</string>
+        </dict>
+      </plist>
+    service: |
+      run "#{bin}/wiresteward", "-agent"
+    test: |
       system "#{bin}/wiresteward", "-version"
-    install: |-
+    install: |
       bin.install "wiresteward"


### PR DESCRIPTION
Enable `brew install utilitywarehouse/tap/wiresteward`

I'd like to validate the release by merging & tagging `v0.2.6` before raising a PR to update the docs.
OSX/Linux users using Homebrew can then just `brew update && brew upgrade` to get a new version of Wiresteward.

Manage via `brew services` which will start up in agent mode as this is most common.

```
brew sevices start utilitywarehouse/tap/wiresteward
brew sevices stop utilitywarehouse/tap/wiresteward
brew sevices restart utilitywarehouse/tap/wiresteward
```

This will look for the config file in the default location `/etc/wiresteward/config.json`