### PR TITLE
Fix homebrew error "Formula specified both service and plist"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,3 @@ brews:
           <string>/var/log/wiresteward.log</string>
         </dict>
       </plist>
-    service: |
-      run "#{bin}/wiresteward", "-agent"
-    test: |
-      system "#{bin}/wiresteward", "-version"


### PR DESCRIPTION
Fix
```
==> Fetching utilitywarehouse/tap/wiresteward
==> Downloading https://github.com/utilitywarehouse/wiresteward/releases/download/v0.2.6-RC2/wiresteward_0.2.6-RC2_darwin_arm64
Already downloaded: /Users/rcrowe/Library/Caches/Homebrew/downloads/f44b81d6aeea39c102cc4c78277dbc234b3262e7d172d313310c91c04f03335c--wiresteward_0.2.6-RC2_darwin_arm64
==> Reinstalling utilitywarehouse/tap/wiresteward
Error: Formula specified both service and plist
Error: Cannot link wiresteward
```