### PR TITLE
Replace instance on userdata change - AWS

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -81,14 +81,15 @@ resource "aws_eip_association" "peer" {
 }
 
 resource "aws_instance" "peer" {
-  count                  = local.instance_count
-  ami                    = var.ami_id != "" ? var.ami_id : data.aws_ami.flatcar_stable.id
-  instance_type          = "t2.micro"
-  vpc_security_group_ids = concat([aws_security_group.wiresteward.id], var.additional_security_group_ids)
-  subnet_id              = var.subnet_ids[count.index]
-  source_dest_check      = false
-  user_data              = data.template_file.userdata[count.index].rendered
-  iam_instance_profile   = aws_iam_instance_profile.peer.name
+  count                       = local.instance_count
+  ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.flatcar_stable.id
+  instance_type               = "t2.micro"
+  vpc_security_group_ids      = concat([aws_security_group.wiresteward.id], var.additional_security_group_ids)
+  subnet_id                   = var.subnet_ids[count.index]
+  source_dest_check           = false
+  user_data                   = data.template_file.userdata[count.index].rendered
+  user_data_replace_on_change = true
+  iam_instance_profile        = aws_iam_instance_profile.peer.name
 
   lifecycle {
     ignore_changes = [ami]


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#user_data_replace_on_change

Our update script currently relies on the instances being replaced on
userdata change
