### PR TITLE
Default aws deployment to t3a instance family

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -83,7 +83,7 @@ resource "aws_eip_association" "peer" {
 resource "aws_instance" "peer" {
   count                       = local.instance_count
   ami                         = var.ami_id != "" ? var.ami_id : data.aws_ami.flatcar_stable.id
-  instance_type               = "t2.micro"
+  instance_type               = "t3a.micro"
   vpc_security_group_ids      = concat([aws_security_group.wiresteward.id], var.additional_security_group_ids)
   subnet_id                   = var.subnet_ids[count.index]
   source_dest_check           = false


### PR DESCRIPTION
Lower costs and better performance compared to t2