### PR TITLE
Stop logging errors during normal operation

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -66,7 +66,7 @@ func (a *Agent) ListenAndServe() {
 
 	token, err := a.oa.getTokenFromFile()
 	if err != nil || token.AccessToken == "" || token.Expiry.Before(time.Now()) {
-		logger.Errorf("cannot get a valid cached token, you need to authenticate")
+		logger.Verbosef("cannot get a valid cached token, you need to authenticate")
 	} else {
 		a.renewAllLeases(token.AccessToken)
 	}
@@ -123,7 +123,7 @@ func (a *Agent) callbackHandler(w http.ResponseWriter, r *http.Request) {
 	a.renewAllLeases(token.AccessToken)
 	// Redirect to / after renewing leases
 	rootURL := fmt.Sprintf("http://%s/", r.Host)
-	http.Redirect(w, r, rootURL, 302)
+	http.Redirect(w, r, rootURL, http.StatusFound)
 }
 
 // renewHandler will initiate the auth challenge. Leases renewal will be handled
@@ -134,7 +134,7 @@ func (a *Agent) renewHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "error creating web url to get token: %v", err)
 		return
 	}
-	http.Redirect(w, r, url, 302)
+	http.Redirect(w, r, url, http.StatusFound)
 }
 
 func (a *Agent) mainHandler(w http.ResponseWriter, r *http.Request) {
@@ -145,9 +145,9 @@ func (a *Agent) mainHandler(w http.ResponseWriter, r *http.Request) {
 
 	token, err := a.oa.getTokenFromFile()
 	if err != nil || token.AccessToken == "" {
-		logger.Errorf("cannot get a valid cached token, you need to authenticate")
-		statusHTTPWriter(w, r, a.deviceManagers, nil)
+		logger.Verbosef("cannot get a valid cached token, you need to authenticate")
+		statusHTTPWriter(w, a.deviceManagers, nil)
 		return
 	}
-	statusHTTPWriter(w, r, a.deviceManagers, token)
+	statusHTTPWriter(w, a.deviceManagers, token)
 }

--- a/agent_http.go
+++ b/agent_http.go
@@ -121,7 +121,7 @@ type httpStatus struct {
 	Routes            []httpRoute
 }
 
-func statusHTTPWriter(w http.ResponseWriter, r *http.Request, deviceManagers []*DeviceManager, token *oauth2.Token) {
+func statusHTTPWriter(w http.ResponseWriter, deviceManagers []*DeviceManager, token *oauth2.Token) {
 	status := httpStatus{
 		Time:         time.Now().Format(timeFmt),
 		TokenMissing: true,

--- a/devicemanager_darwin.go
+++ b/devicemanager_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin
+//go:build darwin
 
 package main
 
@@ -46,7 +46,7 @@ func (dm *DeviceManager) updateDeviceConfig(oldConfig, config *WirestewardPeerCo
 		// routes via interfaces.
 		for _, r := range oldConfig.AllowedIPs {
 			if err := delRoute(fdRoute, oldConfig.LocalAddress.IP, r.IP, r.Mask); err != nil {
-				logger.Errorf(
+				logger.Verbosef(
 					"Could not remove old route (%s): %s",
 					r,
 					err,

--- a/devicemanager_linux.go
+++ b/devicemanager_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package main
 
@@ -22,8 +22,8 @@ func (dm *DeviceManager) updateDeviceConfig(oldConfig, config *WirestewardPeerCo
 	}
 	if oldConfig != nil {
 		for _, r := range oldConfig.AllowedIPs {
-			if h.RouteDel(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: &r}); err != nil {
-				logger.Errorf(
+			if err := h.RouteDel(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: &r}); err != nil {
+				logger.Verbosef(
 					"Could not remove old route (%s): %s",
 					r,
 					err,
@@ -59,23 +59,6 @@ func (dm *DeviceManager) ensureLinkUp() error {
 		return err
 	}
 	return h.LinkSetUp(link)
-}
-
-func (dm *DeviceManager) flushAddresses() error {
-	h := netlink.Handle{}
-	defer h.Delete()
-	link, err := h.LinkByName(dm.Name())
-	if err != nil {
-		return err
-	}
-
-	ips, err := h.AddrList(link, 2)
-	for _, ip := range ips {
-		if err := h.AddrDel(link, &ip); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func wgDevTypeSupported() bool {

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -17,13 +17,12 @@ type healthCheck struct {
 	renew      chan struct{} // Chan to notify for a reboot
 }
 
-func newHealthCheck(device, address string, interval, intervalAF, timeout Duration, threshold int, renew chan struct{}) (*healthCheck, error) {
-	pc, err := newPingChecker(device, address, timeout)
+func newHealthCheck(address string, interval, intervalAF, timeout Duration, threshold int, renew chan struct{}) (*healthCheck, error) {
+	pc, err := newPingChecker(address, timeout)
 	if err != nil {
 		return &healthCheck{}, err
 	}
 	return &healthCheck{
-		device:     device,
 		checker:    pc,
 		interval:   interval,
 		intervalAF: intervalAF,
@@ -53,7 +52,7 @@ func (hc *healthCheck) Run() {
 				unhealthyCount = unhealthyCount + 1
 				healthSyncTicker.Reset(hc.intervalAF.Duration)
 				errStr := err.Error()
-				if strings.Contains(errStr, "i/o timeout") || strings.Contains(errStr, "network is unreachable") || strings.Contains(errStr, "token is expired") {
+				if strings.Contains(errStr, "i/o timeout") || strings.Contains(errStr, "network is unreachable") {
 					logger.Verbosef("healthcheck failed for peer %s@%s (%s)", hc.checker.TargetIP(), hc.device, err)
 				} else {
 					logger.Errorf("healthcheck failed for peer %s@%s (%s)", hc.checker.TargetIP(), hc.device, err)

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestHealthcheck_NewHealthCheck(t *testing.T) {
 	hc, err := newHealthCheck(
-		"test-dev",
 		"10.0.0.0",
 		Duration{10 * time.Second},
 		Duration{time.Second},
@@ -34,7 +33,6 @@ func TestHealthcheck_RunConsecutiveFails(t *testing.T) {
 
 	renewNotify := make(chan struct{})
 	hc, err := newHealthCheck(
-		"test-dev",
 		"10.0.0.0",
 		Duration{100 * time.Millisecond},
 		Duration{10 * time.Millisecond},
@@ -72,7 +70,6 @@ func TestHealthcheck_RunHealthyCheckResets(t *testing.T) {
 
 	renewNotify := make(chan struct{})
 	hc, err := newHealthCheck(
-		"test-dev",
 		"10.0.0.0",
 		Duration{100 * time.Millisecond},
 		Duration{10 * time.Millisecond},

--- a/lease_test.go
+++ b/lease_test.go
@@ -64,11 +64,11 @@ func TestGetAvailableIPAddresses(t *testing.T) {
 	}
 
 	testCases := []struct {
-		t fileLeaseManager
+		t *fileLeaseManager
 		e netip.Addr
 	}{
 		{
-			t: *lm,
+			t: lm,
 			e: netip.MustParseAddr("10.90.0.3"),
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -170,8 +170,6 @@ func agent() {
 		close(term)
 	}()
 
-	select {
-	case <-term:
-	}
+	<-term
 	agent.Stop()
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -46,11 +46,11 @@ func TestCollector(t *testing.T) {
 							ReceiveBytes:      1,
 							TransmitBytes:     2,
 							AllowedIPs: []net.IPNet{
-								net.IPNet{
+								{
 									IP:   net.ParseIP("10.0.0.1"),
 									Mask: net.CIDRMask(32, 32),
 								},
-								net.IPNet{
+								{
 									IP:   net.ParseIP("10.0.0.2"),
 									Mask: net.CIDRMask(32, 32),
 								},
@@ -64,7 +64,7 @@ func TestCollector(t *testing.T) {
 							{
 								PublicKey: pubPeerB,
 								AllowedIPs: []net.IPNet{
-									net.IPNet{
+									{
 										IP:   net.ParseIP("10.0.0.3"),
 										Mask: net.CIDRMask(32, 32),
 									},
@@ -73,7 +73,7 @@ func TestCollector(t *testing.T) {
 							{
 								PublicKey: pubPeerC, // Not in the leases
 								AllowedIPs: []net.IPNet{
-									net.IPNet{
+									{
 										IP:   net.ParseIP("10.0.0.4"),
 										Mask: net.CIDRMask(32, 32),
 									},
@@ -85,12 +85,12 @@ func TestCollector(t *testing.T) {
 			},
 			leaseManager: &fileLeaseManager{
 				wgRecords: map[string]WGRecord{
-					userA: WGRecord{
+					userA: {
 						PubKey:  pubPeerA.String(),
 						IP:      netip.MustParseAddr("10.0.0.1"),
 						expires: time.Unix(100, 0),
 					},
-					userB: WGRecord{
+					userB: {
 						PubKey: pubPeerB.String(),
 						IP:     netip.MustParseAddr("10.0.0.3"),
 					},

--- a/ping.go
+++ b/ping.go
@@ -27,7 +27,7 @@ type checker interface {
 	TargetIP() string
 }
 
-func newPingChecker(device, address string, timeout Duration) (*pingChecker, error) {
+func newPingChecker(address string, timeout Duration) (*pingChecker, error) {
 	ip := netip.MustParseAddr(address)
 	id := nextPingCheckerID
 	nextPingCheckerID++

--- a/serve.go
+++ b/serve.go
@@ -110,7 +110,7 @@ func (lh *HTTPLeaseHandler) newPeerLease(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "cannot encode response", http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprint(w, string(r))
+		w.Write(r)
 
 	default:
 		fmt.Fprint(w, "only POST method is supported.")


### PR DESCRIPTION
When token is expired, we should not be logging errors about it or
timeouts.
