### PR TITLE
Support multiple OAuth servers with OIDC discovery

### DIFF
--- a/config.go
+++ b/config.go
@@ -142,6 +142,15 @@ func readAgentConfig(path string) (*agentConfig, error) {
 	return conf, nil
 }
 
+// oauthServerConfig describes a single OAuth server the wiresteward server
+// accepts tokens from. The introspection endpoint is discovered at startup via
+// OIDC discovery (`<server>/.well-known/openid-configuration`). Tokens are
+// routed to the matching server based on the JWT `iss` claim.
+type oauthServerConfig struct {
+	Server   string `json:"server"`
+	ClientID string `json:"clientID"`
+}
+
 // serverConfig describes the server-side configuration of wiresteward.
 type serverConfig struct {
 	Address             string
@@ -154,24 +163,22 @@ type serverConfig struct {
 	LeasesFilename      string
 	WireguardIPPrefix   netip.Prefix
 	WireguardListenPort int
-	OauthIntrospectURL  string
-	OauthClientID       string
+	OauthServers        []oauthServerConfig
 	ServerListenAddress string
 }
 
 func (c *serverConfig) UnmarshalJSON(data []byte) error {
 	cfg := &struct {
-		Address             string   `json:"address"`
-		AllowedIPs          []string `json:"allowedIPs"`
-		DeviceMTU           int      `json:"deviceMTU"`
-		DeviceName          string   `json:"deviceName"`
-		Endpoint            string   `json:"endpoint"`
-		KeyFilename         string   `json:"keyFilename"`
-		LeaserSyncInterval  string   `json:"leaserSyncInterval"`
-		LeasesFilename      string   `json:"leasesFilename"`
-		OauthIntrospectURL  string   `json:"oauthIntrospectURL"`
-		OauthClientID       string   `json:"oauthClientID"`
-		ServerListenAddress string   `json:"serverListenAddress"`
+		Address             string              `json:"address"`
+		AllowedIPs          []string            `json:"allowedIPs"`
+		DeviceMTU           int                 `json:"deviceMTU"`
+		DeviceName          string              `json:"deviceName"`
+		Endpoint            string              `json:"endpoint"`
+		KeyFilename         string              `json:"keyFilename"`
+		LeaserSyncInterval  string              `json:"leaserSyncInterval"`
+		LeasesFilename      string              `json:"leasesFilename"`
+		OauthServers        []oauthServerConfig `json:"oauthServers"`
+		ServerListenAddress string              `json:"serverListenAddress"`
 	}{}
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return err
@@ -190,8 +197,7 @@ func (c *serverConfig) UnmarshalJSON(data []byte) error {
 	c.Endpoint = cfg.Endpoint
 	c.KeyFilename = cfg.KeyFilename
 	c.LeasesFilename = cfg.LeasesFilename
-	c.OauthIntrospectURL = cfg.OauthIntrospectURL
-	c.OauthClientID = cfg.OauthClientID
+	c.OauthServers = cfg.OauthServers
 	c.ServerListenAddress = cfg.ServerListenAddress
 	return nil
 }
@@ -279,11 +285,16 @@ func verifyServerConfig(conf *serverConfig, allowPublicRoutes bool) error {
 			defaultLeasesFilename,
 		)
 	}
-	if conf.OauthIntrospectURL == "" {
-		return fmt.Errorf("config missing `oauthIntrospectURL`")
+	if len(conf.OauthServers) == 0 {
+		return fmt.Errorf("config missing `oauthServers`, at least one entry is required")
 	}
-	if conf.OauthClientID == "" {
-		return fmt.Errorf("config missing `oauthClientID`")
+	for i, s := range conf.OauthServers {
+		if s.Server == "" {
+			return fmt.Errorf("oauthServers[%d] missing `server`", i)
+		}
+		if s.ClientID == "" {
+			return fmt.Errorf("oauthServers[%d] missing `clientID`", i)
+		}
 	}
 	if conf.ServerListenAddress == "" {
 		conf.ServerListenAddress = defaultServerListenAddress

--- a/config_test.go
+++ b/config_test.go
@@ -153,8 +153,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "10.0.0.1/24",
 				"allowedIPs": ["192.168.1.0/24"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			&serverConfig{
 				Address:             "10.0.0.1/24",
@@ -166,8 +167,39 @@ func TestServerConfig(t *testing.T) {
 				LeasesFilename:      defaultLeasesFilename,
 				WireguardIPPrefix:   ipPrefix,
 				WireguardListenPort: 1234,
-				OauthIntrospectURL:  "example.com",
-				OauthClientID:       "client_id",
+				OauthServers: []oauthServerConfig{
+					{Server: "https://idp.example.com", ClientID: "client_id"},
+				},
+				ServerListenAddress: "0.0.0.0:8080",
+			},
+			false,
+			false,
+		},
+		{
+			// Multiple issuers configured
+			[]byte(`{
+				"address": "10.0.0.1/24",
+				"allowedIPs": ["192.168.1.0/24"],
+				"endpoint": "1.2.3.4:1234",
+				"oauthServers": [
+					{"server": "https://idp1.example.com", "clientID": "client_id_1"},
+					{"server": "https://idp2.example.com", "clientID": "client_id_2"}
+				]
+			}`),
+			&serverConfig{
+				Address:             "10.0.0.1/24",
+				AllowedIPs:          []string{"192.168.1.0/24", "10.0.0.1/32"},
+				DeviceName:          "wg0",
+				Endpoint:            "1.2.3.4:1234",
+				KeyFilename:         defaultKeyFilename,
+				LeaserSyncInterval:  defaultLeaserSyncInterval,
+				LeasesFilename:      defaultLeasesFilename,
+				WireguardIPPrefix:   ipPrefix,
+				WireguardListenPort: 1234,
+				OauthServers: []oauthServerConfig{
+					{Server: "https://idp1.example.com", ClientID: "client_id_1"},
+					{Server: "https://idp2.example.com", ClientID: "client_id_2"},
+				},
 				ServerListenAddress: "0.0.0.0:8080",
 			},
 			false,
@@ -182,8 +214,9 @@ func TestServerConfig(t *testing.T) {
 				"keyFilename": "bar",
 				"leaserSyncInterval": "3h",
 				"leasesFilename": "foo",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			&serverConfig{
 				Address:             "10.0.0.1/24",
@@ -196,12 +229,38 @@ func TestServerConfig(t *testing.T) {
 				LeaserSyncInterval:  time.Duration(time.Hour * 3),
 				WireguardIPPrefix:   ipPrefix,
 				WireguardListenPort: 12345,
-				OauthIntrospectURL:  "example.com",
-				OauthClientID:       "client_id",
+				OauthServers: []oauthServerConfig{
+					{Server: "https://idp.example.com", ClientID: "client_id"},
+				},
 				ServerListenAddress: "0.0.0.0:8080",
 			},
 			false,
 			false,
+		},
+		{
+			// Missing oauthServers — should fail
+			[]byte(`{
+				"address": "10.0.0.1/24",
+				"allowedIPs": ["192.168.1.0/24"],
+				"endpoint": "1.2.3.4:1234"
+			}`),
+			nil,
+			false,
+			true,
+		},
+		{
+			// oauthServers entry missing clientID — should fail
+			[]byte(`{
+				"address": "10.0.0.1/24",
+				"allowedIPs": ["192.168.1.0/24"],
+				"endpoint": "1.2.3.4:1234",
+				"oauthServers": [
+					{"server": "https://idp.example.com"}
+				]
+			}`),
+			nil,
+			false,
+			true,
 		},
 		{
 			// Public CIDR without override flag — should fail
@@ -209,8 +268,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "10.0.0.1/24",
 				"allowedIPs": ["1.2.3.4/8"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			nil,
 			false,
@@ -223,8 +283,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "10.0.0.1/24",
 				"allowedIPs": ["10.0.0.0/2"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			nil,
 			false,
@@ -236,8 +297,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "10.0.0.1/24",
 				"allowedIPs": ["1.2.3.4/8"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			&serverConfig{
 				Address:             "10.0.0.1/24",
@@ -249,8 +311,9 @@ func TestServerConfig(t *testing.T) {
 				LeasesFilename:      defaultLeasesFilename,
 				WireguardIPPrefix:   ipPrefix,
 				WireguardListenPort: 1234,
-				OauthIntrospectURL:  "example.com",
-				OauthClientID:       "client_id",
+				OauthServers: []oauthServerConfig{
+					{Server: "https://idp.example.com", ClientID: "client_id"},
+				},
 				ServerListenAddress: "0.0.0.0:8080",
 			},
 			true,
@@ -262,8 +325,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "1.2.3.4/24",
 				"allowedIPs": ["192.168.1.0/24"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			nil,
 			false,
@@ -275,8 +339,9 @@ func TestServerConfig(t *testing.T) {
 				"address": "1.2.3.4/24",
 				"allowedIPs": ["192.168.1.0/24"],
 				"endpoint": "1.2.3.4:1234",
-				"oauthIntrospectURL": "example.com",
-				"oauthClientID": "client_id"
+				"oauthServers": [
+					{"server": "https://idp.example.com", "clientID": "client_id"}
+				]
 			}`),
 			&serverConfig{
 				Address:             "1.2.3.4/24",
@@ -288,8 +353,9 @@ func TestServerConfig(t *testing.T) {
 				LeasesFilename:      defaultLeasesFilename,
 				WireguardIPPrefix:   netip.MustParsePrefix("1.2.3.4/24"),
 				WireguardListenPort: 1234,
-				OauthIntrospectURL:  "example.com",
-				OauthClientID:       "client_id",
+				OauthServers: []oauthServerConfig{
+					{Server: "https://idp.example.com", ClientID: "client_id"},
+				},
 				ServerListenAddress: "0.0.0.0:8080",
 			},
 			true,

--- a/devicemanager.go
+++ b/devicemanager.go
@@ -174,7 +174,7 @@ func (dm *DeviceManager) renewLease() error {
 	if token == "" {
 		return fmt.Errorf("Empty cached token")
 	}
-	if err := validateJWTToken(token); err != nil {
+	if _, err := validateJWTToken(token); err != nil {
 		return err
 	}
 	publicKey, _, err := getKeys(dm.Name())

--- a/examples/server.json
+++ b/examples/server.json
@@ -2,6 +2,10 @@
   "address": "10.0.0.1/24",
   "allowedIPs": ["10.11.12.0/24"],
   "endpoint": "1.2.3.4:51820",
-  "oauthIntrospectUrl": "https://login.example.com/oauth2/v1/introspect",
-  "oauthClientId": "xxxxxxxxxxxxxxxxx"
+  "oauthServers": [
+    {
+      "server": "https://login.example.com",
+      "clientID": "xxxxxxxxxxxxxxxxx"
+    }
+  ]
 }

--- a/main.go
+++ b/main.go
@@ -114,7 +114,11 @@ func server() {
 		logger.Errorf("Cannot start lease server: %v", err)
 		os.Exit(1)
 	}
-	tv := newTokenValidator(cfg.OauthClientID, cfg.OauthIntrospectURL)
+	tv, err := newTokenValidator(cfg.OauthServers)
+	if err != nil {
+		logger.Errorf("Cannot initialise token validator: %v", err)
+		os.Exit(1)
+	}
 
 	// Start metrics server
 	client, err := wgctrl.New()

--- a/oauth2.go
+++ b/oauth2.go
@@ -203,10 +203,23 @@ func (oa *oauthTokenHandler) ExchangeToken(code string) (*oauth2.Token, error) {
 	return tok, nil
 }
 
+// oauthServer holds the data needed to introspect tokens for a single
+// OAuth server, after discovery has been performed at startup.
+type oauthServer struct {
+	IntrospectionURL string
+	ClientID         string
+}
+
+// oidcDiscoveryDoc is the subset of fields we read from the OIDC discovery
+// document at `<server>/.well-known/openid-configuration`.
+type oidcDiscoveryDoc struct {
+	Issuer                string `json:"issuer"`
+	IntrospectionEndpoint string `json:"introspection_endpoint"`
+}
+
 type tokenValidator struct {
-	httpClient         *http.Client
-	oauthClientID      string
-	oauthIntrospectURL string
+	httpClient *http.Client
+	servers    map[string]oauthServer // keyed by issuer (matches JWT `iss`)
 }
 
 type introspectionResponse struct {
@@ -215,22 +228,63 @@ type introspectionResponse struct {
 	UserName string `json:"username"`
 }
 
-func newTokenValidator(clientID, introspectURL string) *tokenValidator {
-	return &tokenValidator{
-		httpClient:         &http.Client{},
-		oauthClientID:      clientID,
-		oauthIntrospectURL: introspectURL,
+// newTokenValidator builds a tokenValidator by performing OIDC discovery
+// against each configured OAuth server. It returns an error if any discovery
+// request fails, returns an `issuer` that does not match the configured
+// server URL, or omits the `introspection_endpoint` field.
+func newTokenValidator(servers []oauthServerConfig) (*tokenValidator, error) {
+	tv := &tokenValidator{
+		httpClient: &http.Client{},
+		servers:    make(map[string]oauthServer, len(servers)),
 	}
+	for _, s := range servers {
+		doc, err := fetchOIDCDiscovery(tv.httpClient, s.Server)
+		if err != nil {
+			return nil, fmt.Errorf("oauth server %q: discovery failed: %w", s.Server, err)
+		}
+		if doc.Issuer != s.Server {
+			return nil, fmt.Errorf("oauth server %q: discovery returned mismatched issuer %q", s.Server, doc.Issuer)
+		}
+		if doc.IntrospectionEndpoint == "" {
+			return nil, fmt.Errorf("oauth server %q: discovery missing `introspection_endpoint`", s.Server)
+		}
+		tv.servers[doc.Issuer] = oauthServer{
+			IntrospectionURL: doc.IntrospectionEndpoint,
+			ClientID:         s.ClientID,
+		}
+	}
+	return tv, nil
 }
 
-func (tv *tokenValidator) requestIntospection(token, tokenTypeHint string) ([]byte, error) {
+func fetchOIDCDiscovery(client *http.Client, server string) (*oidcDiscoveryDoc, error) {
+	url := strings.TrimRight(server, "/") + "/.well-known/openid-configuration"
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	doc := &oidcDiscoveryDoc{}
+	if err := json.Unmarshal(body, doc); err != nil {
+		return nil, fmt.Errorf("decode discovery doc: %w", err)
+	}
+	return doc, nil
+}
+
+func (tv *tokenValidator) requestIntospection(token, tokenTypeHint string, s oauthServer) ([]byte, error) {
 	data := url.Values{}
 	data.Set("token", token)
 	data.Set("token_type_hint", tokenTypeHint)
-	data.Set("client_id", tv.oauthClientID)
+	data.Set("client_id", s.ClientID)
 	req, err := http.NewRequest(
 		"POST",
-		tv.oauthIntrospectURL,
+		s.IntrospectionURL,
 		strings.NewReader(data.Encode()),
 	)
 	if err != nil {
@@ -254,13 +308,21 @@ func (tv *tokenValidator) requestIntospection(token, tokenTypeHint string) ([]by
 	return body, nil
 }
 
-// validate takes a token and queries the introspection endpoint with it.
+// validate takes a token, parses its issuer from the JWT, and queries the
+// matching introspection endpoint.
 // https://tools.ietf.org/html/rfc7662#section-2.2
 func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionResponse, error) {
-	if err := validateJWTToken(token); err != nil {
+	issuer, err := validateJWTToken(token)
+	if err != nil {
 		return nil, fmt.Errorf("Validation failed: %v", err)
 	}
-	body, err := tv.requestIntospection(token, tokenTypeHint)
+	s, ok := tv.servers[issuer]
+	if !ok {
+		logger.Errorf("No oauth server configured for issuer %q", issuer)
+		return nil, fmt.Errorf("no oauth server configured for issuer %q", issuer)
+	}
+	logger.Verbosef("Token matched oauth server for issuer %q", issuer)
+	body, err := tv.requestIntospection(token, tokenTypeHint, s)
 	if err != nil {
 		return nil, err
 	}
@@ -272,27 +334,28 @@ func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionR
 	return response, nil
 }
 
-// validateJWTToken takes a string and tries to validate it as jwt token. It
-// returns an error if parsing and validation fails or nil otherwise
-func validateJWTToken(t string) error {
+// validateJWTToken takes a string and tries to validate it as a jwt token. On
+// success it returns the issuer (`iss` claim) found in the token. It returns
+// an error if parsing or validation fails.
+func validateJWTToken(t string) (string, error) {
 	tok, err := jwt.ParseSigned(t, supportedAlgValues)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cl := jwt.Claims{}
 	if err := tok.UnsafeClaimsWithoutVerification(&cl); err != nil {
-		return err
+		return "", err
 	}
 
 	if cl.Expiry == nil {
-		return fmt.Errorf("JWT token does not have exp field")
+		return "", fmt.Errorf("JWT token does not have exp field")
 	}
 	// Validate Claims
 	if err := cl.ValidateWithLeeway(jwt.Expected{
 		Time: time.Now(),
 	}, 0); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return cl.Issuer, nil
 }

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -29,17 +31,17 @@ func TestValidateJWTToken(t *testing.T) {
 		t.Fatalf("unable to creat jwt token %s", err)
 	}
 
-	err = validateJWTToken(tok)
+	_, err = validateJWTToken(tok)
 	expectedErr := fmt.Errorf("%v", jwt.ErrExpired)
 	if err == nil {
 		t.Fatal("Validation of expired token did not fail")
 	}
 	assert.Equal(t, err, expectedErr)
 
-	// Non expired token
+	// Non expired token — issuer should be returned
 	activeCL := jwt.Claims{
 		Subject: "subject",
-		Issuer:  "issuer",
+		Issuer:  "https://idp.example.com",
 		Expiry:  jwt.NewNumericDate(time.Now().Add(+1 * time.Minute)),
 	}
 	tok, err = jwt.Signed(signer).Claims(activeCL).Serialize()
@@ -47,10 +49,11 @@ func TestValidateJWTToken(t *testing.T) {
 		t.Fatalf("unable to creat jwt token %s", err)
 	}
 
-	err = validateJWTToken(tok)
+	issuer, err := validateJWTToken(tok)
 	if err != nil {
 		t.Fatalf("Error validating token: %v", err)
 	}
+	assert.Equal(t, "https://idp.example.com", issuer)
 
 	// Missing exp field
 	missingExpCL := jwt.Claims{
@@ -62,11 +65,97 @@ func TestValidateJWTToken(t *testing.T) {
 		t.Fatalf("unable to creat jwt token %s", err)
 	}
 
-	err = validateJWTToken(tok)
+	_, err = validateJWTToken(tok)
 	expectedErr = fmt.Errorf("JWT token does not have exp field")
 	if err == nil {
 		t.Fatal("Validation of expired token did not fail")
 	}
 	assert.Equal(t, err, expectedErr)
 
+}
+
+// expectedOktaDiscoveryDoc mirrors the response served by an Okta OAuth
+// server (taken verbatim from a real /.well-known/openid-configuration
+// response, with only the host substituted to the test server URL).
+const expectedOktaDiscoveryDoc = `{"issuer":"%[1]s","authorization_endpoint":"%[1]s/v1/authorize","token_endpoint":"%[1]s/v1/token","userinfo_endpoint":"%[1]s/v1/userinfo","registration_endpoint":"%[1]s/v1/clients","jwks_uri":"%[1]s/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","offline_access"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","name","email"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"%[1]s/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","none"],"revocation_endpoint":"%[1]s/v1/revoke","end_session_endpoint":"%[1]s/v1/logout"}`
+
+func TestNewTokenValidator_realisticOktaDiscovery(t *testing.T) {
+	setLogLevel("error")
+	logger = newLogger("wiresteward-test")
+
+	var serverURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, expectedOktaDiscoveryDoc, serverURL)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	tv, err := newTokenValidator([]oauthServerConfig{
+		{Server: serverURL, ClientID: "test-client"},
+	})
+	if err != nil {
+		t.Fatalf("newTokenValidator: %v", err)
+	}
+
+	resolved, ok := tv.servers[serverURL]
+	assert.True(t, ok, "issuer should be registered in validator")
+	assert.Equal(t, serverURL+"/v1/introspect", resolved.IntrospectionURL)
+	assert.Equal(t, "test-client", resolved.ClientID)
+}
+
+func TestNewTokenValidator_issuerMismatch(t *testing.T) {
+	setLogLevel("error")
+	logger = newLogger("wiresteward-test")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// issuer in the doc does not match the configured server URL
+		fmt.Fprint(w, `{"issuer":"https://wrong.example.com","introspection_endpoint":"https://wrong.example.com/introspect"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := newTokenValidator([]oauthServerConfig{
+		{Server: srv.URL, ClientID: "test-client"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatched issuer")
+}
+
+func TestNewTokenValidator_missingIntrospectionEndpoint(t *testing.T) {
+	setLogLevel("error")
+	logger = newLogger("wiresteward-test")
+
+	var serverURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"issuer":"%s"}`, serverURL)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	_, err := newTokenValidator([]oauthServerConfig{
+		{Server: serverURL, ClientID: "test-client"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "introspection_endpoint")
+}
+
+func TestNewTokenValidator_unreachable(t *testing.T) {
+	setLogLevel("error")
+	logger = newLogger("wiresteward-test")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // close immediately so requests fail
+
+	_, err := newTokenValidator([]oauthServerConfig{
+		{Server: srv.URL, ClientID: "test-client"},
+	})
+	assert.Error(t, err)
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,8 +17,7 @@ locals {
 module "wiresteward_ignition" {
   source = "github.com/utilitywarehouse/wiresteward//terraform/ignition?ref=master"
 
-  oauth2_client_id           = "xxxxxxxxxxxxxxxxxxxxx"
-  oauth2_introspect_url      = "https://login.uw.systems/oauth2/default/v1/introspect"
+  oauth_servers              = [{ server = "https://login.uw.systems/oauth2/default", client_id = "xxxxxxxxxxxxxxxxxxxxx" }]
   wireguard_cidrs            = ["10.10.0.1/24", "10.10.0.2/24"]
   wireguard_endpoint_base    = local.hostname_base
   wireguard_exposed_subnets  = ["10.20.0.0/16"]

--- a/terraform/ignition/ignition.tf
+++ b/terraform/ignition/ignition.tf
@@ -10,8 +10,7 @@ data "ignition_file" "wiresteward_config" {
       wireguard_cidr            = var.wireguard_cidrs[count.index]
       wireguard_endpoint        = local.wireguard_endpoints[count.index]
       wireguard_exposed_subnets = var.wireguard_exposed_subnets
-      oauth2_introspect_url     = var.oauth2_introspect_url
-      oauth2_client_id          = var.oauth2_client_id
+      oauth_servers             = var.oauth_servers
     })
   }
 }

--- a/terraform/ignition/io.tf
+++ b/terraform/ignition/io.tf
@@ -15,14 +15,12 @@ variable "omit_locksmithd_service" {
   default     = false
 }
 
-variable "oauth2_introspect_url" {
-  type        = string
-  description = "Introspection url to validate access tokens"
-}
-
-variable "oauth2_client_id" {
-  type        = string
-  description = "Oauth client id. Used for token validation"
+variable "oauth_servers" {
+  type = list(object({
+    server    = string
+    client_id = string
+  }))
+  description = "List of OAuth servers to accept tokens from. Each entry needs the server base URL (used for OIDC discovery) and a client ID."
 }
 
 variable "wireguard_cidrs" {

--- a/terraform/ignition/resources/wiresteward-config.json.tmpl
+++ b/terraform/ignition/resources/wiresteward-config.json.tmpl
@@ -2,6 +2,5 @@
   "address": "${wireguard_cidr}",
   "allowedIPs": ${jsonencode(wireguard_exposed_subnets)},
   "endpoint": "${wireguard_endpoint}:51820",
-  "oauthIntrospectUrl": "${oauth2_introspect_url}",
-  "oauthClientId": "${oauth2_client_id}"
+  "oauthServers": ${jsonencode([for s in oauth_servers : { server = s.server, clientID = s.client_id }])}
 }

--- a/terraform/matchbox/README.md
+++ b/terraform/matchbox/README.md
@@ -42,8 +42,7 @@ variable "wiresteward_server_peers" {
 module "wiresteward_ignition" {
   source = "github.com/utilitywarehouse/wiresteward//terraform/ignition?ref=master"
 
-  oauth2_client_id           = "xxxxxxxxxxxxxxxxxxxxx"
-  oauth2_introspect_url      = "https://login.uw.systems/oauth2/default/v1/introspect"
+  oauth_servers              = [{ server = "https://login.uw.systems/oauth2/default", client_id = "xxxxxxxxxxxxxxxxxxxxx" }]
   wireguard_cidrs            = var.wiresteward_server_peers.*.wireguard_cidr
   wireguard_endpoint_base    = local.hostname_base
   wireguard_exposed_subnets  = ["10.20.0.0/16"]


### PR DESCRIPTION
Replace oauthIntrospectURL + oauthClientID with an oauthServers list, where each entry specifies a server URL and clientID. At startup, the server fetches each server's /.well-known/openid-configuration to discover the introspection endpoint and verify the issuer. Incoming tokens are routed to the correct introspection endpoint by matching the JWT iss claim against discovered issuers.