### PR TITLE
Fix deadlocks from unbuffered channel signals across goroutine lifecycles

### DIFF
--- a/devicemanager.go
+++ b/devicemanager.go
@@ -49,9 +49,9 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string, http
 		backoff:              newBackoff(1*time.Second, 64*time.Second, 2),
 		healthCheck:          &healthCheck{running: false},
 		healthCheckConf:      hcc,
-		renewLeaseChan:       make(chan struct{}),
-		healthCheckRenewChan: make(chan struct{}),
-		stopLeaseBackoff:     make(chan struct{}),
+		renewLeaseChan:       make(chan struct{}, 1),
+		healthCheckRenewChan: make(chan struct{}, 1),
+		stopLeaseBackoff:     make(chan struct{}, 1),
 		inBackoffLoop:        false,
 		httpClientTimeout:    httpClientTimeout,
 	}
@@ -158,10 +158,16 @@ func (dm *DeviceManager) nextServer() string {
 func (dm *DeviceManager) triggerLeaseRenewal() {
 	dm.healthCheck.Stop() // stop a running healthcheck that could also trigger renewals
 	if dm.inBackoffLoop {
-		dm.stopLeaseBackoff <- struct{}{} // Stop existing backoff loops
+		select {
+		case dm.stopLeaseBackoff <- struct{}{}:
+		default:
+		}
 	}
 	dm.backoff.Reset() // Reset backoff timer
-	dm.renewLeaseChan <- struct{}{}
+	select {
+	case dm.renewLeaseChan <- struct{}{}:
+	default:
+	}
 }
 
 // renewLease uses the provided oauth2 token to retrieve a new leases from one

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -58,6 +58,14 @@ func (hc *healthCheck) Run() {
 
 				// if unhealthy count exceeds the threshold we need to stop the health check and look for a new lease
 				if unhealthyCount >= hc.threshold {
+					// Check if we've been asked to stop before triggering a renewal
+					select {
+					case <-hc.stop:
+						logger.Verbosef("stopping healthcheck for: %s", hc.checker.TargetIP())
+						hc.running = false
+						return
+					default:
+					}
 					logger.Verbosef("server at: %s marked unhealthy, need to renew lease", hc.checker.TargetIP())
 					hc.running = false
 					hc.healthy = false

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -12,7 +12,7 @@ type healthCheck struct {
 	threshold  int
 	healthy    bool
 	running    bool          // bool to help us identify running healthchecks and stop them if needed
-	stop       chan struct{} // Chan to signal hc to stop
+	stop       chan struct{} // Buffered(1) chan to signal hc to stop; buffered so Stop() never blocks if the goroutine already exited
 	renew      chan struct{} // Chan to notify for a reboot
 }
 
@@ -29,14 +29,17 @@ func newHealthCheck(device, address string, interval, intervalAF, timeout Durati
 		threshold:  threshold,
 		healthy:    false, // assume target is not healthy when starting until we make a successful check
 		running:    false,
-		stop:       make(chan struct{}),
+		stop:       make(chan struct{}, 1),
 		renew:      renew,
 	}, nil
 }
 
 func (hc *healthCheck) Stop() {
 	if hc.running {
-		hc.stop <- struct{}{}
+		select {
+		case hc.stop <- struct{}{}:
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
Buffer healthcheck stop, renewLeaseChan, healthCheckRenewChan, and stopLeaseBackoff channels (size 1) and use non-blocking sends. This prevents deadlocks when the receiving goroutine has already exited or is busy in an HTTP request and cannot read from the channel.