### PR TITLE
Use atomic.Bool for healthcheck running and healthy fields

### DIFF
--- a/agent_http.go
+++ b/agent_http.go
@@ -145,7 +145,7 @@ func statusHTTPWriter(w http.ResponseWriter, r *http.Request, deviceManagers []*
 					Dst:             ip.String(),
 					GW:              dm.config.LocalAddress.String(),
 					IsHealthChecked: dm.isHealthChecked(),
-					Healthy:         dm.healthCheck.healthy,
+					Healthy:         dm.healthCheck.healthy.Load(),
 				}
 				routes = append(routes, r)
 			}

--- a/devicemanager.go
+++ b/devicemanager.go
@@ -47,7 +47,7 @@ func newDeviceManager(deviceName string, mtu int, wirestewardURLs []string, http
 		agentDevice:          device,
 		serverURLs:           wirestewardURLs,
 		backoff:              newBackoff(1*time.Second, 64*time.Second, 2),
-		healthCheck:          &healthCheck{running: false},
+		healthCheck:          &healthCheck{},
 		healthCheckConf:      hcc,
 		renewLeaseChan:       make(chan struct{}, 1),
 		healthCheckRenewChan: make(chan struct{}, 1),

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync/atomic"
 	"time"
 )
 
@@ -10,8 +11,8 @@ type healthCheck struct {
 	interval   Duration
 	intervalAF Duration
 	threshold  int
-	healthy    bool
-	running    bool          // bool to help us identify running healthchecks and stop them if needed
+	healthy    atomic.Bool
+	running    atomic.Bool
 	stop       chan struct{} // Buffered(1) chan to signal hc to stop; buffered so Stop() never blocks if the goroutine already exited
 	renew      chan struct{} // Chan to notify for a reboot
 }
@@ -27,15 +28,13 @@ func newHealthCheck(device, address string, interval, intervalAF, timeout Durati
 		interval:   interval,
 		intervalAF: intervalAF,
 		threshold:  threshold,
-		healthy:    false, // assume target is not healthy when starting until we make a successful check
-		running:    false,
 		stop:       make(chan struct{}, 1),
 		renew:      renew,
 	}, nil
 }
 
 func (hc *healthCheck) Stop() {
-	if hc.running {
+	if hc.running.Load() {
 		select {
 		case hc.stop <- struct{}{}:
 		default:
@@ -47,7 +46,7 @@ func (hc *healthCheck) Run() {
 	healthSyncTicker := time.NewTicker(hc.interval.Duration)
 	defer healthSyncTicker.Stop()
 	var unhealthyCount int
-	hc.running = true
+	hc.running.Store(true)
 	for {
 		select {
 		case <-healthSyncTicker.C:
@@ -62,21 +61,21 @@ func (hc *healthCheck) Run() {
 					select {
 					case <-hc.stop:
 						logger.Verbosef("stopping healthcheck for: %s", hc.checker.TargetIP())
-						hc.running = false
+						hc.running.Store(false)
 						return
 					default:
 					}
 					logger.Verbosef("server at: %s marked unhealthy, need to renew lease", hc.checker.TargetIP())
-					hc.running = false
-					hc.healthy = false
+					hc.running.Store(false)
+					hc.healthy.Store(false)
 					hc.renew <- struct{}{}
 					return
 				}
 			} else {
-				if !hc.healthy {
+				if !hc.healthy.Load() {
 					logger.Verbosef("server at: %s is healthy", hc.checker.TargetIP())
 				}
-				hc.healthy = true
+				hc.healthy.Store(true)
 				if unhealthyCount > 0 {
 					unhealthyCount = 0
 					healthSyncTicker.Reset(hc.interval.Duration)
@@ -84,7 +83,7 @@ func (hc *healthCheck) Run() {
 			}
 		case <-hc.stop:
 			logger.Verbosef("stopping healthcheck for: %s", hc.checker.TargetIP())
-			hc.running = false
+			hc.running.Store(false)
 			return
 		}
 	}

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -47,6 +47,10 @@ func (hc *healthCheck) Run() {
 	defer healthSyncTicker.Stop()
 	var unhealthyCount int
 	hc.running.Store(true)
+	defer hc.running.Store(false)
+
+	var triggerRenew bool
+
 	for {
 		select {
 		case <-healthSyncTicker.C:
@@ -61,15 +65,11 @@ func (hc *healthCheck) Run() {
 					select {
 					case <-hc.stop:
 						logger.Verbosef("stopping healthcheck for: %s", hc.checker.TargetIP())
-						hc.running.Store(false)
 						return
 					default:
 					}
 					logger.Verbosef("server at: %s marked unhealthy, need to renew lease", hc.checker.TargetIP())
-					hc.running.Store(false)
-					hc.healthy.Store(false)
-					hc.renew <- struct{}{}
-					return
+					triggerRenew = true
 				}
 			} else {
 				if !hc.healthy.Load() {
@@ -81,9 +81,15 @@ func (hc *healthCheck) Run() {
 					healthSyncTicker.Reset(hc.interval.Duration)
 				}
 			}
+
 		case <-hc.stop:
 			logger.Verbosef("stopping healthcheck for: %s", hc.checker.TargetIP())
-			hc.running.Store(false)
+			return
+		}
+
+		if triggerRenew {
+			hc.healthy.Store(false)
+			hc.renew <- struct{}{}
 			return
 		}
 	}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -23,8 +23,8 @@ func TestHealthcheck_NewHealthCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Assert init healthcheck conditions
-	assert.Equal(t, hc.healthy, false)
-	assert.Equal(t, hc.running, false)
+	assert.Equal(t, hc.healthy.Load(), false)
+	assert.Equal(t, hc.running.Load(), false)
 }
 
 func TestHealthcheck_RunConsecutiveFails(t *testing.T) {


### PR DESCRIPTION
These fields are written by the Run() goroutine and read by Stop() and the HTTP handler from other goroutines without synchronization. Plain bool provides no memory visibility guarantees across goroutines and is flagged by the race detector. atomic.Bool provides lock-free correctly synchronized access.