### PR TITLE
Add per-issuer token validation metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,6 +119,11 @@ func server() {
 		logger.Errorf("Cannot initialise token validator: %v", err)
 		os.Exit(1)
 	}
+	issuers := make([]string, 0, len(tv.servers))
+	for iss := range tv.servers {
+		issuers = append(issuers, iss)
+	}
+	initTokenValidationMetrics(issuers)
 
 	// Start metrics server
 	client, err := wgctrl.New()

--- a/metrics.go
+++ b/metrics.go
@@ -9,6 +9,30 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+// tokenValidations counts token validations performed against each
+// configured oauth server. The `issuer` label is bounded by the number of
+// configured servers, and `result` is one of a small fixed set of values
+// (active, inactive, error), keeping cardinality minimal.
+var tokenValidations = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "wiresteward_token_validations_total",
+		Help: "Number of token validations performed, labelled by oauth server issuer and outcome.",
+	},
+	[]string{"issuer", "result"},
+)
+
+// initTokenValidationMetrics registers the tokenValidations counter and
+// pre-initialises every (issuer, result) series to 0 so that unused oauth
+// servers are visible as flat-zero counters rather than missing series.
+func initTokenValidationMetrics(issuers []string) {
+	prometheus.MustRegister(tokenValidations)
+	for _, iss := range issuers {
+		for _, r := range []string{"active", "inactive", "error"} {
+			tokenValidations.WithLabelValues(iss, r).Add(0)
+		}
+	}
+}
+
 // A collector is a prometheus.Collector for a WireGuard device.
 type collector struct {
 	DeviceInfo          *prometheus.Desc

--- a/oauth2.go
+++ b/oauth2.go
@@ -324,13 +324,20 @@ func (tv *tokenValidator) validate(token, tokenTypeHint string) (*introspectionR
 	logger.Verbosef("Token matched oauth server for issuer %q", issuer)
 	body, err := tv.requestIntospection(token, tokenTypeHint, s)
 	if err != nil {
+		tokenValidations.WithLabelValues(issuer, "error").Inc()
 		return nil, err
 	}
 
 	response := &introspectionResponse{}
 	if err := json.Unmarshal(body, response); err != nil {
+		tokenValidations.WithLabelValues(issuer, "error").Inc()
 		return nil, err
 	}
+	result := "inactive"
+	if response.Active {
+		result = "active"
+	}
+	tokenValidations.WithLabelValues(issuer, result).Inc()
 	return response, nil
 }
 


### PR DESCRIPTION
Counter wiresteward_token_validations_total labelled by issuer and result (active/inactive/error).