### PR TITLE
Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds grouping to dependabot config so GitHub Actions PRs are batched instead of one per action.