### PR TITLE
Pin Go build toolchain to the exact version in go.mod

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -5,8 +5,6 @@ on:
     tags:
       - "*"
   pull_request:
-  schedule:
-    - cron: "0 10 * * *" # daily at 10:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
   pull_request:
   schedule:
-    - cron: "0 10 * * *" # daily at 10:00 UTC
+    - cron: "0 9 * * WED" # every wednesday at 9:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM golang:1.26-alpine AS build
 WORKDIR /go/src/github.com/utilitywarehouse/wiresteward
 COPY . /go/src/github.com/utilitywarehouse/wiresteward
 ENV CGO_ENABLED=0
+# GOTOOLCHAIN pins the exact toolchain declared by go.mod's `go` line, so the
+# build isn't at the mercy of whatever patch version the base image ships.
 RUN apk --no-cache add git upx \
       && go get -t ./... \
       && go test -v \
+      && GOTOOLCHAIN=go$(awk '/^go /{print $2; exit}' go.mod) \
       && go build -ldflags='-s -w' -o /wiresteward . \
       && upx /wiresteward
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/utilitywarehouse/wiresteward
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/coreos/go-iptables v0.8.0


### PR DESCRIPTION
Matching settings with other repos:
- Remove scheduled go tests
- Set scheduled govulncheck jobs to run once a week